### PR TITLE
Added schema resolver

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
       tests/unit
       --cov src
       --cov-report term-missing
-      --cov-fail-under 80
+      --cov-fail-under 97
       --random-order-bucket parent
       -vv
     language: system

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,7 @@ cfn_guard_rs==0.1.2
 colorama>=0.4.1
 coverage>=4.5.4
 Jinja2==2.11.3
+jsonschema>=3.0.1,<4.0
 markupsafe==2.0.1
 pip==21.1
 pre-commit>=2.21.0

--- a/src/rpdk/guard_rail/utils/schema_utils.py
+++ b/src/rpdk/guard_rail/utils/schema_utils.py
@@ -1,0 +1,53 @@
+"""Module to handle schema manipulations."""
+from typing import Dict, Any, Set
+from jsonschema import RefResolver
+
+_PROPERTIES = "properties"
+_REF = "$ref"
+_ITEMS = "items"
+_PATTERN_PROPERTIES = "patternProperties"
+_ANY_OF = "anyOf"
+_ONE_OF = "oneOf"
+_ALL_OF = "allOf"
+
+
+def resolve_schema(schema: Dict):
+    """Resolving schema into a nested object.
+    Json schema allows recursive and chained
+    $refs, which is hard to analyze and get diff
+    between two schemas. This method resolves refs;
+    Args:
+        schema (Dict): _description_
+    Returns:
+        _type_: _description_
+    """
+    resolver = RefResolver.from_schema(schema)
+    def _internal_resolver(schema: Dict, resolver: Any, resolved_refs: Set):
+        if _PROPERTIES in schema:
+            for key, val in schema[_PROPERTIES].items():
+                schema[_PROPERTIES][key] = _internal_resolver(val, resolver, resolved_refs)
+        if _REF in schema:
+            reference_path = schema.pop(_REF, None)
+            if reference_path in resolved_refs:
+                return schema
+            resolved = resolver.resolve(reference_path)[1]
+            schema.update(resolved)
+            return _internal_resolver(schema, resolver, resolved_refs | {reference_path})
+        if _PATTERN_PROPERTIES in schema:
+            for key, val in schema[_PATTERN_PROPERTIES].items():
+                schema[_PATTERN_PROPERTIES][key] = _internal_resolver(val, resolver, resolved_refs)
+        if _ITEMS in schema:
+            schema[_ITEMS] = _internal_resolver(schema[_ITEMS], resolver, resolved_refs)
+        if _ALL_OF in schema:
+            for index, element in enumerate(schema[_ALL_OF]):
+                schema[_ALL_OF][index] = _internal_resolver(element, resolver, resolved_refs)
+        if _ANY_OF in schema:
+            for index, element in enumerate(schema[_ANY_OF]):
+                schema[_ANY_OF][index] = _internal_resolver(element, resolver, resolved_refs)
+        if _ONE_OF in schema:
+            for index, element in enumerate(schema[_ONE_OF]):
+                schema[_ONE_OF][index] = _internal_resolver(element, resolver, resolved_refs)
+        return schema
+    resolved_schema = _internal_resolver(schema, resolver, set())
+    resolved_schema.pop("definitions", None)
+    return resolved_schema

--- a/tests/unit/utils/data/schemas-for-testing/schema-with-chained-refs.json
+++ b/tests/unit/utils/data/schemas-for-testing/schema-with-chained-refs.json
@@ -1,0 +1,259 @@
+{
+    "definitions": {
+        "NewPropertyRef": {
+            "$ref": "#/definitions/NewPropertyRef2"
+        },
+        "NewPropertyRef2": {
+            "$ref": "#/definitions/NewProperty"
+        },
+        "ConfigurationItem": {
+            "type": "object",
+            "properties": {
+                "Name": {
+                    "type": "string"
+                },
+                "Configurations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ConfigurationItem"
+                    }
+                }
+            }
+        },
+        "NewProperty": {
+            "type": "object",
+            "properties": {
+                "Name": {
+                    "type": "string",
+                    "minLength": 0,
+                    "maxLength": 129
+                }
+            }
+        },
+        "Tag": {
+            "type": "object",
+            "anyOf":[
+                {
+                    "properties": {
+                        "Key": {
+                            "type": "string",
+                            "pattern": "*"
+                        },
+                        "Value": {
+                            "type": "string",
+                            "minLength": 0,
+                            "maxLength": 256
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Key"
+                    ]
+                },
+                {
+                    "properties": {
+                        "Key": {
+                            "type": "string",
+                            "pattern": "*"
+                        },
+                        "Value2": {
+                            "type": "string",
+                            "minLength": 0,
+                            "maxLength": 256
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Key",
+                        "Value2"
+                    ]
+                },
+                {
+                    "type" : "object",
+                    "description" : "This resource type use map for Tags, suggest to use List of Tag",
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        ".*": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "properties": {
+        "NewProperty": {
+            "$ref": "#/definitions/NewPropertyRef"
+        },
+        
+        "Configurations": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/ConfigurationItem"
+            }
+        },
+        
+        "Description": {
+            "type": "string",
+            "pattern": ""
+        },
+        "Enabled": {
+            "type": "boolean"
+        },
+        "EnableKeyRotation": {
+            "type": "boolean"
+        },
+        "KeyPolicy": {
+            "type": "object"
+        },
+        "KeyUsage": {
+            "type": "string",
+            "default": "ENCRYPT_DECRYPT",
+            "enum": [
+                "ENCRYPT_DECRYPT",
+                "SIGN_VERIFY",
+                "GENERATE_VERIFY_MAC"
+            ]
+        },
+        "KeySpec": {
+            "type": "string",
+            "default": "SYMMETRIC_DEFAULT",
+            "enum": [
+                "SYMMETRIC_DEFAULT",
+                "RSA_2048",
+                "RSA_3072",
+                "RSA_4096",
+                "ECC_NIST_P256",
+                "ECC_NIST_P384",
+                "ECC_NIST_P521",
+                "ECC_SECG_P256K1",
+                "HMAC_224",
+                "HMAC_256",
+                "HMAC_384",
+                "HMAC_512",
+                "SM2"
+            ]
+        },
+        "MultiRegion": {
+            "type": "boolean",
+            "default": false
+        },
+        "PendingWindowInDays": {
+            "type": "integer",
+            "minimum": 7,
+            "maximum": 30
+        },
+        "Tags2": {
+            "type": "array",
+            "uniqueItems": true,
+            "insertionOrder": false,
+            "items": {
+                "$ref": "#/definitions/Tag"
+            }
+        },
+        "Tags3": {
+            "type": "array",
+            "uniqueItems": true,
+            "insertionOrder": false,
+            "items": {
+                "anyOf": [
+                    {
+                        "$ref": "#/definitions/Tag"
+                    }
+                ]
+            }
+        },
+        "Tags4": {
+            "type": "array",
+            "uniqueItems": true,
+            "insertionOrder": false,
+            "items": {
+                "allOf": [
+                    {
+                        "$ref": "#/definitions/Tag"
+                    }
+                ]
+            }
+        },
+        "Tags5": {
+            "type": "array",
+            "uniqueItems": true,
+            "insertionOrder": false,
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "#/definitions/Tag"
+                    }
+                ]
+            }
+        },
+        "Arn": {
+            "type": "string"
+        },
+        "KeyId": {
+            "type": "number"
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "KeyPolicy",
+        "PendingWindowInDays"
+    ],
+    "readOnlyProperties": [
+    ],
+    "createOnlyProperties": [
+        "/properties/KeyId"
+    ],
+    "primaryIdentifier": [
+        "/properties/KeyId",
+        "/properties/NewProperty/Name"
+    ],
+    "writeOnlyProperties": [
+        "/properties/PendingWindowInDays",
+        "/properties/KeyPolicy"
+    ],
+    "handlers": {
+        "create": {
+            "permissions": [
+                "kms:CreateKey",
+                "kms:CreateKeyNew", 
+                "kms:EnableKeyRotation",
+                "kms:DisableKey",
+                "kms:TagResource"
+            ]
+        },
+        "read": {
+            "permissions": [
+                "kms:DescribeKey",
+                "kms:GetKeyPolicy",
+                "kms:GetKeyRotationStatus",
+                "kms:ListResourceTags"
+            ]
+        },
+        "update": {
+            "permissions": [
+                "kms:DescribeKey",
+                "kms:DisableKey",
+                "kms:DisableKeyRotation",
+                "kms:EnableKey",
+                "kms:EnableKeyRotation",
+                "kms:PutKeyPolicy",
+                "kms:TagResource",
+                "kms:UntagResource",
+                "kms:UpdateKeyDescription"
+            ]
+        },
+        "delete": {
+            "permissions": [
+                "kms:DescribeKey",
+                "kms:ScheduleKeyDeletion"
+            ]
+        },
+        "list": {
+            "permissions": [
+                "kms:ListKeys",
+                "kms:DescribeKey"
+            ]
+        }
+    }
+}

--- a/tests/unit/utils/data/schemas-for-verifying/schema-with-chained-refs.json
+++ b/tests/unit/utils/data/schemas-for-verifying/schema-with-chained-refs.json
@@ -1,0 +1,284 @@
+{
+    "properties": {
+        "NewProperty": {
+            "type": "object",
+            "properties": {
+                "Name": {
+                    "type": "string",
+                    "minLength": 0,
+                    "maxLength": 129
+                }
+            }
+        },
+        "Configurations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Name": {
+                        "type": "string"
+                    },
+                    "Configurations": {
+                        "type": "array",
+                        "items": {}
+                    }
+                }
+            }
+        },
+        "Description": {
+            "type": "string",
+            "pattern": ""
+        },
+        "Enabled": {
+            "type": "boolean"
+        },
+        "EnableKeyRotation": {
+            "type": "boolean"
+        },
+        "KeyPolicy": {
+            "type": "object"
+        },
+        "KeyUsage": {
+            "type": "string",
+            "default": "ENCRYPT_DECRYPT",
+            "enum": ["ENCRYPT_DECRYPT", "SIGN_VERIFY", "GENERATE_VERIFY_MAC"]
+        },
+        "KeySpec": {
+            "type": "string",
+            "default": "SYMMETRIC_DEFAULT",
+            "enum": ["SYMMETRIC_DEFAULT", "RSA_2048", "RSA_3072", "RSA_4096", "ECC_NIST_P256", "ECC_NIST_P384", "ECC_NIST_P521", "ECC_SECG_P256K1", "HMAC_224", "HMAC_256", "HMAC_384", "HMAC_512", "SM2"]
+        },
+        "MultiRegion": {
+            "type": "boolean",
+            "default": false
+        },
+        "PendingWindowInDays": {
+            "type": "integer",
+            "minimum": 7,
+            "maximum": 30
+        },
+        "Tags2": {
+            "type": "array",
+            "uniqueItems": true,
+            "insertionOrder": false,
+            "items": {
+                "type": "object",
+                "anyOf": [{
+                    "properties": {
+                        "Key": {
+                            "type": "string",
+                            "pattern": "*"
+                        },
+                        "Value": {
+                            "type": "string",
+                            "minLength": 0,
+                            "maxLength": 256
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": ["Key"]
+                }, {
+                    "properties": {
+                        "Key": {
+                            "type": "string",
+                            "pattern": "*"
+                        },
+                        "Value2": {
+                            "type": "string",
+                            "minLength": 0,
+                            "maxLength": 256
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": ["Key", "Value2"]
+                },
+                {
+                    "type": "object",
+                    "description": "This resource type use map for Tags, suggest to use List of Tag",
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        ".*": {
+                            "type": "string"
+                        }
+                    }
+                }]
+            }
+        },
+        "Tags3": {
+            "type": "array",
+            "uniqueItems": true,
+            "insertionOrder": false,
+            "items": {
+                "anyOf": [{
+                    "type": "object",
+                    "anyOf": [{
+                        "properties": {
+                            "Key": {
+                                "type": "string",
+                                "pattern": "*"
+                            },
+                            "Value": {
+                                "type": "string",
+                                "minLength": 0,
+                                "maxLength": 256
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": ["Key"]
+                    }, {
+                        "properties": {
+                            "Key": {
+                                "type": "string",
+                                "pattern": "*"
+                            },
+                            "Value2": {
+                                "type": "string",
+                                "minLength": 0,
+                                "maxLength": 256
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": ["Key", "Value2"]
+                    },
+                    {
+                        "type": "object",
+                        "description": "This resource type use map for Tags, suggest to use List of Tag",
+                        "additionalProperties": false,
+                        "patternProperties": {
+                            ".*": {
+                                "type": "string"
+                            }
+                        }
+                    }]
+                }]
+            }
+        },
+        "Tags4": {
+            "type": "array",
+            "uniqueItems": true,
+            "insertionOrder": false,
+            "items": {
+                "allOf": [{
+                    "type": "object",
+                    "anyOf": [{
+                        "properties": {
+                            "Key": {
+                                "type": "string",
+                                "pattern": "*"
+                            },
+                            "Value": {
+                                "type": "string",
+                                "minLength": 0,
+                                "maxLength": 256
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": ["Key"]
+                    }, {
+                        "properties": {
+                            "Key": {
+                                "type": "string",
+                                "pattern": "*"
+                            },
+                            "Value2": {
+                                "type": "string",
+                                "minLength": 0,
+                                "maxLength": 256
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": ["Key", "Value2"]
+                    },
+                    {
+                        "type": "object",
+                        "description": "This resource type use map for Tags, suggest to use List of Tag",
+                        "additionalProperties": false,
+                        "patternProperties": {
+                            ".*": {
+                                "type": "string"
+                            }
+                        }
+                    }]
+                }]
+            }
+        },
+        "Tags5": {
+            "type": "array",
+            "uniqueItems": true,
+            "insertionOrder": false,
+            "items": {
+                "oneOf": [{
+                    "type": "object",
+                    "anyOf": [{
+                        "properties": {
+                            "Key": {
+                                "type": "string",
+                                "pattern": "*"
+                            },
+                            "Value": {
+                                "type": "string",
+                                "minLength": 0,
+                                "maxLength": 256
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": ["Key"]
+                    }, {
+                        "properties": {
+                            "Key": {
+                                "type": "string",
+                                "pattern": "*"
+                            },
+                            "Value2": {
+                                "type": "string",
+                                "minLength": 0,
+                                "maxLength": 256
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": ["Key", "Value2"]
+                    },
+                    {
+                        "type": "object",
+                        "description": "This resource type use map for Tags, suggest to use List of Tag",
+                        "additionalProperties": false,
+                        "patternProperties": {
+                            ".*": {
+                                "type": "string"
+                            }
+                        }
+                    }]
+                }]
+            }
+        },
+        "Arn": {
+            "type": "string"
+        },
+        "KeyId": {
+            "type": "number"
+        }
+    },
+    "additionalProperties": false,
+    "required": ["KeyPolicy", "PendingWindowInDays"],
+    "readOnlyProperties": [],
+    "createOnlyProperties": ["/properties/KeyId"],
+    "primaryIdentifier": ["/properties/KeyId", "/properties/NewProperty/Name"],
+    "writeOnlyProperties": ["/properties/PendingWindowInDays", "/properties/KeyPolicy"],
+    "handlers": {
+        "create": {
+            "permissions": ["kms:CreateKey", "kms:CreateKeyNew", "kms:EnableKeyRotation", "kms:DisableKey", "kms:TagResource"]
+        },
+        "read": {
+            "permissions": ["kms:DescribeKey", "kms:GetKeyPolicy", "kms:GetKeyRotationStatus", "kms:ListResourceTags"]
+        },
+        "update": {
+            "permissions": ["kms:DescribeKey", "kms:DisableKey", "kms:DisableKeyRotation", "kms:EnableKey", "kms:EnableKeyRotation", "kms:PutKeyPolicy", "kms:TagResource", "kms:UntagResource", "kms:UpdateKeyDescription"]
+        },
+        "delete": {
+            "permissions": ["kms:DescribeKey", "kms:ScheduleKeyDeletion"]
+        },
+        "list": {
+            "permissions": ["kms:ListKeys", "kms:DescribeKey"]
+        }
+    }
+}

--- a/tests/unit/utils/test_schema_utils.py
+++ b/tests/unit/utils/test_schema_utils.py
@@ -1,0 +1,30 @@
+"""unittest module to test schema utils"""
+import os
+from pathlib import Path
+import pytest
+from src.rpdk.guard_rail.utils.schema_utils import resolve_schema
+from src.rpdk.guard_rail.utils.arg_handler import collect_schemas
+
+@pytest.mark.parametrize(
+    "schema,result",
+    [
+        (
+            "data/schemas-for-testing/schema-with-chained-refs.json",
+            "data/schemas-for-verifying/schema-with-chained-refs.json"
+        )
+    ]
+)
+def test_resolve_schema(schema, result):
+    """Unit test to verify resolve_schema method"""
+    try:
+        collected_schemas_to_resolve = collect_schemas(schemas=[
+            "file:/"
+            + str(Path(os.path.dirname(os.path.realpath(__file__))).joinpath(schema))
+        ])
+        collected_schemas_to_verify = collect_schemas(schemas=[
+            "file:/"
+            + str(Path(os.path.dirname(os.path.realpath(__file__))).joinpath(result))
+        ])
+        assert resolve_schema(collected_schemas_to_resolve[0]) == collected_schemas_to_verify[0]
+    except IOError as e:
+        assert "No such file or directory: " in str(e)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Schema resolver method, which resolves all the `$ref` pointers within following constructs:
* `properties`
* `$ref`
* `items`
* `anyOf`
* `oneOf`
* `allOf`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
