### PR TITLE
fix: Print diff as JSON string

### DIFF
--- a/src/rpdk/guard_rail/core/stateful.py
+++ b/src/rpdk/guard_rail/core/stateful.py
@@ -18,6 +18,7 @@ Typical usage example:
     schema_v2 = ...
     schema_meta_diff = schema_diff(schema_v1, schema_v2)
 """
+import json
 import re
 from copy import copy
 from enum import auto
@@ -88,7 +89,7 @@ def schema_diff(previous_json: Dict[str, Any], current_json: Dict[str, Any]):
         ignore_order=True,
         verbose_level=2,
     )
-    print(_translate_meta_diff(deep_diff.to_dict()))
+    print(json.dumps(_translate_meta_diff(deep_diff.to_dict())))
     return _translate_meta_diff(deep_diff.to_dict())
 
 


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
This message is currently printing as a dict which makes it difficult for a user to pretty-print it. Outputting it as JSON makes it easier to pretty-print using other tools like jq.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
