### PR TITLE
Fix path regex for schema and guard

### DIFF
--- a/src/rpdk/guard_rail/utils/arg_handler.py
+++ b/src/rpdk/guard_rail/utils/arg_handler.py
@@ -155,7 +155,7 @@ def collect_schemas(schemas: Sequence[str] = None):
 
             if schema_deser is None:
                 schema_input_path_validation(schema_item)
-                path = "/" + re.search(JSON_PATH_EXTRACT_PATTERN, schema_item).group(0)
+                path = "/" + re.search(JSON_PATH_EXTRACT_PATTERN, schema_item).group(2)
                 file_obj = read_file(path)
                 schema_deser = __to_json(file_obj)
 
@@ -180,7 +180,7 @@ def collect_rules(rules: Sequence[str] = None):
             rule_input_path_validation(rule)
 
             if re.search(GUARD_FILE_PATTERN, rule):
-                path = "/" + re.search(GUARD_PATH_EXTRACT_PATTERN, rule).group(0)
+                path = "/" + re.search(GUARD_PATH_EXTRACT_PATTERN, rule).group(2)
                 file_obj = read_file(path)
                 _rules.append(file_obj)
 

--- a/src/rpdk/guard_rail/utils/common.py
+++ b/src/rpdk/guard_rail/utils/common.py
@@ -11,8 +11,8 @@ SCHEMA_FILE_PATTERN = re.compile(r"^(.+)\/([^\/]+)(\.json)$")
 GUARD_FILE_PATTERN = re.compile(r"^(.+)\/([^\/]+)(\.guard)$")
 
 
-JSON_PATH_EXTRACT_PATTERN = r"(?![file:\/])(.+)\/([^\/]+)(\.json)$"
-GUARD_PATH_EXTRACT_PATTERN = r"(?![file:\/])(.+)\/([^\/]+)(\.guard)$"
+JSON_PATH_EXTRACT_PATTERN = r"(^file:/)((.+)(\.json))$"
+GUARD_PATH_EXTRACT_PATTERN = r"(^file:/)((.+)(\.guard))$"
 
 
 @logdebug


### PR DESCRIPTION
*Issue #, if available:*
Previous regex `JSON_PATH_EXTRACT_PATTERN = r"(?![file:\/])(.+)\/([^\/]+)(\.json)$"` was causing issues when the path starts with any of the following (f,i,l,e,:,/) characters, removing them from the beginning due to the negative lookahead.

*Description of changes:*
Fixed the regex to pick the correct path

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
