### PR TITLE
Added Regex test to Verify property path

### DIFF
--- a/docs/BASIC_LINTING.md
+++ b/docs/BASIC_LINTING.md
@@ -17,6 +17,11 @@
 | |  `PR002` | `"create/readOnlyProperties MUST NOT have common properties"` |
 | `ensure_write_and_read_only_intersection_is_empty` |  `PR003` | `"read/writeOnlyProperties MUST NOT have common properties"` |
 | |  `PR004` | `"write/readOnlyProperties MUST NOT have common properties"` |
+| `verify_property_notation` |  `PR005` | `"primaryIdentifier MUST have correct property notation 'properties/..'"` |
+| |  `PR006` | `"createOnlyProperties MUST have correct property notation 'properties/..'"` |
+| |  `PR007` | `"readOnlyProperties MUST have correct property notation 'properties/..'"` |
+| |  `PR008` | `"writeOnlyProperties MUST have correct property notation 'properties/..'"` |
+
 
 #### Combiners
 | Rule Name   |      Check Id      |  Message |

--- a/src/rpdk/guard_rail/rule_library/core/schema-linter-core-rules.guard
+++ b/src/rpdk/guard_rail/rule_library/core/schema-linter-core-rules.guard
@@ -117,6 +117,62 @@ rule ensure_write_and_read_only_intersection_is_empty
     }
 }
 
+rule verify_property_notation
+{
+    let allowedPattern = /(\/properties\/)\w+/
+    when primaryIdentifier exists {
+        primaryIdentifier[*] {
+            this == %allowedPattern
+            <<
+            {
+                "result": "NON_COMPLIANT",
+                "check_id": "PR005",
+                "message": "primaryIdentifier MUST have correct property notation `properties/..`"
+            }
+            >>
+        }
+    }
+
+    when createOnlyProperties exists {
+        createOnlyProperties[*] {
+            this == %allowedPattern
+            <<
+            {
+                "result": "NON_COMPLIANT",
+                "check_id": "PR006",
+                "message": "createOnlyProperties MUST have correct property notation `properties/..`"
+            }
+            >>
+        }
+    }
+
+    when readOnlyProperties exists {
+        readOnlyProperties[*] {
+            this == %allowedPattern
+            <<
+            {
+                "result": "NON_COMPLIANT",
+                "check_id": "PR007",
+                "message": "readOnlyProperties MUST have correct property notation `properties/..`"
+            }
+            >>
+        }
+    }
+
+    when writeOnlyProperties exists {
+        writeOnlyProperties[*] {
+            this == %allowedPattern
+            <<
+            {
+                "result": "NON_COMPLIANT",
+                "check_id": "PR008",
+                "message": "writeOnlyProperties MUST have correct property notation `properties/..`"
+            }
+            >>
+        }
+    }
+}
+
 
 
 rule ensure_description_is_descriptive {

--- a/tests/integ/data/sample-schema.json
+++ b/tests/integ/data/sample-schema.json
@@ -113,18 +113,21 @@
     ],
     "readOnlyProperties": [
         "/properties/Arn",
-        "/properties/KeyId"
+        "/properties/KeyId",
+        "/Properties/KeyId2"
     ],
     "createOnlyProperties": [
-        "/properties/KeyPolicy"
+        "/properties/KeyPolicy",
+        "/Properties/KeyPolicy2"
     ],
     "primaryIdentifier": [
         "/properties/KeyPolicy",
         "/properties/KeyId",
-        "/properties/Arn2"
+        "/Properties/Arn2"
     ],
     "writeOnlyProperties": [
-        "/properties/PendingWindowInDays"
+        "/properties/PendingWindowInDays",
+        "/Properties/PendingWindowInDays2"
     ],
     "taggable": true,
     "handlers": {

--- a/tests/integ/runner/test_integ_runner.py
+++ b/tests/integ/runner/test_integ_runner.py
@@ -48,6 +48,28 @@ from rpdk.guard_rail.utils.arg_handler import collect_schemas
                         path="",
                     )
                 },
+                "verify_property_notation": {
+                    GuardRuleResult(
+                        check_id="PR005",
+                        message="primaryIdentifier MUST have correct property notation `properties/..`",
+                        path="/primaryIdentifier/2",
+                    ),
+                    GuardRuleResult(
+                        check_id="PR006",
+                        message="createOnlyProperties MUST have correct property notation `properties/..`",
+                        path="/createOnlyProperties/1",
+                    ),
+                    GuardRuleResult(
+                        check_id="PR007",
+                        message="readOnlyProperties MUST have correct property notation `properties/..`",
+                        path="/readOnlyProperties/2",
+                    ),
+                    GuardRuleResult(
+                        check_id="PR008",
+                        message="writeOnlyProperties MUST have correct property notation `properties/..`",
+                        path="/writeOnlyProperties/1",
+                    ),
+                },
             },
             {
                 "check_if_taggable_is_used": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added four more tests to verify that property path has correct prefix - `(\/properties\/)\w+`;
Invalid:
```
{
  "primaryIdentifier": [ "/Properties/KeyId" ]
}
```
Valid:
```
{
  "primaryIdentifier": [ "/properties/KeyId" ]
}
```

There are four major CFN constructs that must hold correct property paths:
* `primaryIdentifier`
* `createOnlyProperties`
* `readOnlyProperties`
* `writeOnlyProperties`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
