### PR TITLE
Changing PAT*/Stateless to Warning

### DIFF
--- a/src/rpdk/guard_rail/rule_library/combiners/schema-linter-combiner-rules.guard
+++ b/src/rpdk/guard_rail/rule_library/combiners/schema-linter-combiner-rules.guard
@@ -9,7 +9,7 @@ rule ensure_properties_do_not_support_multitype {
             '$ref' exists
             <<
             {
-                "result": "NON_COMPLIANT",
+                "result": "WARNING",
                 "check_id": "COM001",
                 "message": "each property MUST specify type"
             }
@@ -17,7 +17,7 @@ rule ensure_properties_do_not_support_multitype {
             type !is_list
             <<
             {
-                "result": "NON_COMPLIANT",
+                "result": "WARNING",
                 "check_id": "COM002",
                 "message": "type MUST NOT have combined definition"
             }
@@ -33,7 +33,7 @@ rule ensure_array_doesnt_use_anyof when %arrays !empty {
         items exists
         <<
         {
-            "result": "NON_COMPLIANT",
+            "result": "WARNING",
             "check_id": "COM003",
             "message": "property array MUST be modeled via items"
         }
@@ -42,7 +42,7 @@ rule ensure_array_doesnt_use_anyof when %arrays !empty {
         items.anyOf not exists
         <<
         {
-            "result": "NON_COMPLIANT",
+            "result": "WARNING",
             "check_id": "COM004",
             "message": "property array MUST NOT specify items via anyOf"
         }
@@ -52,7 +52,7 @@ rule ensure_array_doesnt_use_anyof when %arrays !empty {
         items.allOf not exists
         <<
         {
-            "result": "NON_COMPLIANT",
+            "result": "WARNING",
             "check_id": "COM005",
             "message": "property array MUST NOT specify items via allOf"
         }
@@ -62,7 +62,7 @@ rule ensure_array_doesnt_use_anyof when %arrays !empty {
         items.oneOf not exists
         <<
         {
-            "result": "NON_COMPLIANT",
+            "result": "WARNING",
             "check_id": "COM006",
             "message": "property array MUST NOT specify items via oneOf"
         }

--- a/src/rpdk/guard_rail/rule_library/core/schema-linter-core-arn-rules.guard
+++ b/src/rpdk/guard_rail/rule_library/core/schema-linter-core-arn-rules.guard
@@ -3,7 +3,7 @@ rule ensure_arn_properties_type_string when %props !empty {
     %props.type == 'string'
     <<
     {
-        "result": "NON_COMPLIANT",
+        "result": "WARNING",
         "check_id": "ARN001",
         "message": "arn related property MUST have pattern specified"
     }
@@ -14,7 +14,7 @@ rule ensure_arn_properties_contain_pattern when %props !empty {
     %props.pattern exists
     <<
     {
-        "result": "NON_COMPLIANT",
+        "result": "WARNING",
         "check_id": "ARN002",
         "message": "arn related property MUST have pattern specified"
     }

--- a/src/rpdk/guard_rail/rule_library/core/schema-linter-core-rules.guard
+++ b/src/rpdk/guard_rail/rule_library/core/schema-linter-core-rules.guard
@@ -191,7 +191,7 @@ rule ensure_sourceUrl_uses_https when sourceUrl exists {
     sourceUrl == /^https:/
     <<
     {
-        "result": "NON_COMPLIANT",
+        "result": "WARNING",
         "check_id": "GN002",
         "message": "sourceUrl should use https protocol"
     }

--- a/src/rpdk/guard_rail/rule_library/stateful/schema-stateful-cfn-enforced-checks.guard
+++ b/src/rpdk/guard_rail/rule_library/stateful/schema-stateful-cfn-enforced-checks.guard
@@ -294,7 +294,7 @@ rule ensure_property_string_pattern_not_changed when pattern exists
             this IN %newProps
             <<
             {
-                "result": "NON_COMPLIANT",
+                "result": "WARNING",
                 "check_id": "PAT001",
                 "message": "Only NEWLY ADDED properties can have new pattern added"
             }
@@ -306,7 +306,7 @@ rule ensure_property_string_pattern_not_changed when pattern exists
         pattern.added !exists
         <<
         {
-            "result": "NON_COMPLIANT",
+            "result": "WARNING",
             "check_id": "PAT001",
             "message": "Only NEWLY ADDED properties can have new pattern added"
         }
@@ -316,7 +316,7 @@ rule ensure_property_string_pattern_not_changed when pattern exists
     pattern.removed !exists
     <<
     {
-        "result": "NON_COMPLIANT",
+        "result": "WARNING",
         "check_id": "PAT002",
         "message": "cannot remove PATTERN from a property"
     }
@@ -325,7 +325,7 @@ rule ensure_property_string_pattern_not_changed when pattern exists
     pattern.changed !exists
     <<
     {
-        "result": "NON_COMPLIANT",
+        "result": "WARNING",
         "check_id": "PAT003",
         "message": "cannot change PATTERN of a property"
     }

--- a/src/rpdk/guard_rail/rule_library/tags/schema-linter-core-tagging-rules.guard
+++ b/src/rpdk/guard_rail/rule_library/tags/schema-linter-core-tagging-rules.guard
@@ -15,7 +15,7 @@ rule ensure_tagging_is_specified {
     tagging exists
     <<
     {
-        "result": "WARNING",
+        "result": "NON_COMPLIANT",
         "check_id": "TAG002",
         "message": "`tagging` MUST be specified"
     }
@@ -38,7 +38,7 @@ rule ensure_property_tags_exists_v1 when taggable exists {
         properties.Tags exists
         <<
         {
-            "result": "NON_COMPLIANT",
+            "result": "WARNING",
             "check_id": "TAG004",
             "message": "Resource MUST implement Tags property if `taggable` is true"
         }
@@ -106,7 +106,7 @@ rule ensure_property_tags_exists_v2 when tagging exists {
         properties.Tags exists
         <<
         {
-            "result": "NON_COMPLIANT",
+            "result": "WARNING",
             "check_id": "TAG011",
             "message": "Resource MUST implement Tags property if `tagging.taggable` is true"
         }

--- a/tests/integ/runner/test_integ_runner.py
+++ b/tests/integ/runner/test_integ_runner.py
@@ -27,25 +27,11 @@ from rpdk.guard_rail.utils.arg_handler import collect_schemas
             ),
             [],
             {
-                "ensure_properties_do_not_support_multitype": {
-                    GuardRuleResult(
-                        check_id="COM002",
-                        message="type MUST NOT have combined definition",
-                        path="/properties/KeyPolicy/type",
-                    )
-                },
                 "ensure_primary_identifier_is_read_or_create_only": {
                     GuardRuleResult(
                         check_id="PID003",
                         message="primaryIdentifier MUST be either readOnly or createOnly",
                         path="/primaryIdentifier/2",
-                    )
-                },
-                "ensure_arn_properties_contain_pattern": {
-                    GuardRuleResult(
-                        check_id="ARN002",
-                        message="arn related property MUST have pattern specified",
-                        path="",
                     )
                 },
                 "verify_property_notation": {
@@ -70,20 +56,34 @@ from rpdk.guard_rail.utils.arg_handler import collect_schemas
                         path="/writeOnlyProperties/1",
                     ),
                 },
-            },
-            {
-                "check_if_taggable_is_used": {
-                    GuardRuleResult(
-                        check_id="TAG001",
-                        message="`taggable` is deprecated, please used `tagging` property",
-                        path="/taggable",
-                    )
-                },
                 "ensure_tagging_is_specified": {
                     GuardRuleResult(
                         check_id="TAG002",
                         message="`tagging` MUST be specified",
                         path="",
+                    )
+                },
+            },
+            {
+                "ensure_properties_do_not_support_multitype": {
+                    GuardRuleResult(
+                        check_id="COM002",
+                        message="type MUST NOT have combined definition",
+                        path="/properties/KeyPolicy/type",
+                    )
+                },
+                "ensure_arn_properties_contain_pattern": {
+                    GuardRuleResult(
+                        check_id="ARN002",
+                        message="arn related property MUST have pattern specified",
+                        path="",
+                    )
+                },
+                "check_if_taggable_is_used": {
+                    GuardRuleResult(
+                        check_id="TAG001",
+                        message="`taggable` is deprecated, please used `tagging` property",
+                        path="/taggable",
                     )
                 },
             },
@@ -205,13 +205,6 @@ def test_exec_compliance_stateless(
             ),
             [],
             {
-                "ensure_properties_do_not_support_multitype": {
-                    GuardRuleResult(
-                        check_id="COM001",
-                        message="each property MUST specify type",
-                        path="/properties/Definition",
-                    )
-                },
                 "verify_property_notation": {
                     GuardRuleResult(
                         check_id="PR008",
@@ -220,7 +213,15 @@ def test_exec_compliance_stateless(
                     )
                 },
             },
-            {},
+            {
+                "ensure_properties_do_not_support_multitype": {
+                    GuardRuleResult(
+                        check_id="COM001",
+                        message="each property MUST specify type",
+                        path="/properties/Definition",
+                    )
+                },
+            },
         ),
     ],
 )
@@ -586,23 +587,6 @@ def test_exec_compliance_stateful_json_breaking_changes(
                         path="/maxLength/changed/0/old_value",
                     ),
                 },
-                "ensure_property_string_pattern_not_changed": {
-                    GuardRuleResult(
-                        check_id="PAT001",
-                        message="Only NEWLY ADDED properties can have new pattern added",
-                        path="/pattern/added/0",
-                    ),
-                    GuardRuleResult(
-                        check_id="PAT002",
-                        message="cannot remove PATTERN from a property",
-                        path="/pattern/removed",
-                    ),
-                    GuardRuleResult(
-                        check_id="PAT003",
-                        message="cannot change PATTERN of a property",
-                        path="/pattern/changed",
-                    ),
-                },
                 "ensure_minitems_not_contracted": {
                     GuardRuleResult(
                         check_id="MI001",
@@ -672,7 +656,25 @@ def test_exec_compliance_stateful_json_breaking_changes(
                     ),
                 },
             },
-            [],
+            {
+                "ensure_property_string_pattern_not_changed": {
+                    GuardRuleResult(
+                        check_id="PAT001",
+                        message="Only NEWLY ADDED properties can have new pattern added",
+                        path="/pattern/added/0",
+                    ),
+                    GuardRuleResult(
+                        check_id="PAT002",
+                        message="cannot remove PATTERN from a property",
+                        path="/pattern/removed",
+                    ),
+                    GuardRuleResult(
+                        check_id="PAT003",
+                        message="cannot change PATTERN of a property",
+                        path="/pattern/changed",
+                    ),
+                },
+            },
         ),
     ],
 )
@@ -691,6 +693,9 @@ def test_exec_compliance_stateful_json_validation_breaking_changes(
         assert (
             non_compliant_result == compliance_result.non_compliant[non_compliant_rule]
         )
+    for warning_rule, warning_result in warning_rules.items():
+        assert warning_rule in compliance_result.warning
+        assert warning_result == compliance_result.warning[warning_rule]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change adjusts status of Stateful and Stateless rules:

#### Stateful
* `PAT001` - **"Only NEWLY ADDED properties can have new pattern added"** 
* `PAT002` - **"cannot remove PATTERN from a property"**
* `PAT003` - **"cannot change PATTERN of a property"**

The reasoning behind the change is that we dont have a good way of determining if pattern change is indeed backward incompatible so it generates false positives, also adding a pattern can be a fix rather than a bug. 

#### Stateless
* `schema-linter-combiner-rules.guard` - all rules are `WARNING`
* `schema-linter-core-arn-rules.guard` - all rules are `WARNING`
* `schema-linter-core-rules.guard/GN002` - is `WARNING`
* `schema-linter-core-tagging-rules.guard/TAG002/004/011` - is `NON_COMPLIANT` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
