### PR TITLE
Expand JSON-native constructs

### DIFF
--- a/src/rpdk/guard_rail/core/stateful.py
+++ b/src/rpdk/guard_rail/core/stateful.py
@@ -85,6 +85,7 @@ native_constructs = {
     "items",
     "additionalProperties",
     "uniqueItems",
+    "dependencies",
 }
 
 

--- a/tests/integ/runner/test_integ_runner.py
+++ b/tests/integ/runner/test_integ_runner.py
@@ -266,6 +266,38 @@ def test_exec_compliance_stateless_aws_verifiedpermissions_policy(
             },
             [],
         ),
+        (
+            {
+                "typeName": "AWS::ARCZonalShift::ZonalAutoshiftConfiguration",
+                "description": "Definition of AWS::ARCZonalShift::ZonalAutoshiftConfiguration Resource Type",
+                "definitions": {
+                    "ZonalAutoshiftStatus": {"type": "string", "enum": ["ENABLED"]},
+                },
+                "properties": {
+                    "ZonalAutoshiftStatus": {
+                        "$ref": "#/definitions/ZonalAutoshiftStatus"
+                    },
+                },
+            },
+            {
+                "typeName": "AWS::ARCZonalShift::ZonalAutoshiftConfiguration",
+                "description": "Definition of AWS::ARCZonalShift::ZonalAutoshiftConfiguration Resource Type",
+                "definitions": {
+                    "ZonalAutoshiftStatus": {"type": "string", "enum": ["ENABLED"]},
+                },
+                "properties": {
+                    "ZonalAutoshiftStatus": {
+                        "$ref": "#/definitions/ZonalAutoshiftStatus",
+                        "dependencies": {
+                            "ZonalAutoshiftStatus": ["PracticeRunConfiguration"]
+                        },
+                    },
+                },
+            },
+            [],
+            {},
+            [],
+        ),
     ],
 )
 def test_exec_compliance_stateful(
@@ -279,6 +311,9 @@ def test_exec_compliance_stateful(
             rules=collected_rules,
         )
         compliance_result = exec_compliance(payload)[0]
+        print(compliance_result)
+        if not non_compliant_rules:
+            assert not compliance_result.non_compliant
 
         for non_compliant_rule, non_compliant_result in non_compliant_rules.items():
             assert non_compliant_rule in compliance_result.non_compliant

--- a/tests/integ/runner/test_integ_runner.py
+++ b/tests/integ/runner/test_integ_runner.py
@@ -311,7 +311,7 @@ def test_exec_compliance_stateful(
             rules=collected_rules,
         )
         compliance_result = exec_compliance(payload)[0]
-        print(compliance_result)
+        
         if not non_compliant_rules:
             assert not compliance_result.non_compliant
 

--- a/tests/integ/runner/test_integ_runner.py
+++ b/tests/integ/runner/test_integ_runner.py
@@ -311,7 +311,7 @@ def test_exec_compliance_stateful(
             rules=collected_rules,
         )
         compliance_result = exec_compliance(payload)[0]
-        
+
         if not non_compliant_rules:
             assert not compliance_result.non_compliant
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`"dependencies"` is a json native construct that is used to conditionally apply subschemas. It can be misinterpreted as a subproperty during diff comparison. This change adds it to the list of specified json keywords to ignore during property comparison.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
