### PR TITLE
New Test PrimaryId Cannot be writeOnly

### DIFF
--- a/src/rpdk/guard_rail/rule_library/core/schema-linter-core-rules.guard
+++ b/src/rpdk/guard_rail/rule_library/core/schema-linter-core-rules.guard
@@ -16,6 +16,22 @@ rule ensure_primary_identifier_exists_and_not_empty
         "message": "primaryIdentifier MUST contain values"
     }
     >>
+
+    when primaryIdentifier exists {
+        when writeOnlyProperties exists {
+            let write = writeOnlyProperties
+            primaryIdentifier[*] {
+                this !IN %write
+                <<
+                {
+                    "result": "NON_COMPLIANT",
+                    "check_id": "PID004",
+                    "message": "primaryIdentifier MUST NOT be part of writeOnlyProperties"
+                }
+                >>
+            }
+        }
+    }
 }
 
 rule ensure_primary_identifier_is_read_or_create_only when ensure_primary_identifier_exists_and_not_empty

--- a/tests/integ/data/schema-primary-id-writeonly.json
+++ b/tests/integ/data/schema-primary-id-writeonly.json
@@ -1,0 +1,8 @@
+{
+    "primaryIdentifier": [
+        "/properties/Id"
+    ],
+    "writeOnlyProperties": [
+        "/properties/Id"
+    ]
+}

--- a/tests/integ/runner/test_integ_runner.py
+++ b/tests/integ/runner/test_integ_runner.py
@@ -168,6 +168,29 @@ from rpdk.guard_rail.utils.arg_handler import collect_schemas
             },
             {},
         ),
+        (
+            collect_schemas(
+                schemas=[
+                    "file:/"
+                    + str(
+                        Path(os.path.dirname(os.path.realpath(__file__))).joinpath(
+                            "../data/schema-primary-id-writeonly.json"
+                        )
+                    )
+                ]
+            ),
+            [],
+            {
+                "ensure_primary_identifier_exists_and_not_empty": {
+                    GuardRuleResult(
+                        check_id="PID004",
+                        message="primaryIdentifier MUST NOT be part of writeOnlyProperties",
+                        path="/primaryIdentifier/0",
+                    )
+                },
+            },
+            {},
+        ),
     ],
 )
 def test_exec_compliance_stateless(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding a new test to verify that primary Identifier is not marked as writeOnlyProperties

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
