### PR TITLE
Added stateful test to verify PrimaryIdentifier order

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ pylint>=2.15.10
 pytest-cov>=4.0.0
 pytest-random-order>=1.1.0
 pytest>=7.2.0
+rich==13.7.1
 StrEnum==0.4.10
 wheel==0.38.1

--- a/src/rpdk/guard_rail/core/templates/guard-result-pojo.output
+++ b/src/rpdk/guard_rail/core/templates/guard-result-pojo.output
@@ -17,8 +17,6 @@
     message: {{check.message}}
     {%- endfor -%}
 {% endfor %}
-
-
 {% if failed_rules%}
 {{failed_header}}
 {% for rule, checks in failed_rules.items() %}

--- a/tests/unit/core/test_data_types.py
+++ b/tests/unit/core/test_data_types.py
@@ -52,5 +52,5 @@ def test_success_result_str():
                 }
             )
         )
-        == "---------\n[SKIPPED]:\n\n\n\x1b[32m[PASSED]:\x1b[39m\n\n\n\x1b[33m[WARNING]:\x1b[39m\n\n\n\n\n\x1b[31m[FAILED]:\x1b[39m\n\nENSURE_OLD_PROPERTY_NOT_TURNED_IMMUTABLE:\n    check-id: MI007\n    message: cannot remove minimum from properties\n    path: /minimum/removed\n    \n"  # pylint: disable=C0301
+        == "---------\n[SKIPPED]:\n\n\n\x1b[32m[PASSED]:\x1b[39m\n\n\n\x1b[33m[WARNING]:\x1b[39m\n\n\n\x1b[31m[FAILED]:\x1b[39m\n\nENSURE_OLD_PROPERTY_NOT_TURNED_IMMUTABLE:\n    check-id: MI007\n    message: cannot remove minimum from properties\n    path: /minimum/removed\n    \n"  # pylint: disable=C0301
     )

--- a/tests/unit/core/test_stateful.py
+++ b/tests/unit/core/test_stateful.py
@@ -787,6 +787,52 @@ def test_schema_diff_complex_json_semantics_mutations(
 @pytest.mark.parametrize(
     "schema_variant1, schema_variant2, expected_diff, expected_diff_negative",
     [
+        (
+            {
+                "primaryIdentifier": [
+                    "/properties/A",
+                    "/properties/B",
+                ]
+            },
+            {
+                "primaryIdentifier": [
+                    "/properties/B",
+                    "/properties/A",
+                ]
+            },
+            {
+                "primaryIdentifier": {
+                    "added": ["/properties/B", "/properties/A"],
+                    "removed": ["/properties/A", "/properties/B"],
+                }
+            },
+            {
+                "primaryIdentifier": {
+                    "added": ["/properties/A", "/properties/B"],
+                    "removed": ["/properties/B", "/properties/A"],
+                }
+            },
+        )
+    ],
+)
+def test_schema_diff_primary_identifier_order_change(
+    schema_variant1, schema_variant2, expected_diff, expected_diff_negative
+):
+    """
+
+    Args:
+        schema_variant1:
+        schema_variant2:
+        expected_diff:
+        expected_diff_negative:
+    """
+    assert expected_diff == schema_diff(schema_variant1, schema_variant2)
+    assert expected_diff_negative == schema_diff(schema_variant2, schema_variant1)
+
+
+@pytest.mark.parametrize(
+    "schema_variant1, schema_variant2, expected_diff, expected_diff_negative",
+    [
         # Test Case #1: type changed from scalar to list
         (
             {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

### NEW TEST

This change addresses #49. 


Cloudformation resource schema has following custom top level constructs:
* `primaryIdentifier`
* `readOnlyProperties`
* `createOnlyProperties`
* `writeOnlyProperties`
* `additionalIdentifiers`

Changing order will only impact `primaryIdentifier`. However, since it did not matter for all the other constructs, deep_diff used `ignore_order=True`, which would not detect changing order of the primary identifier. 

This change does diff comparison in two sections:
1. full schema - primaryIdentifier
2. empty schema + primaryIdentifier
Two meta diffs are merged to compose full meta diff. 

**exmaple**

previous schema:
```
{
  ...
  "readOnlyProperties": [
    "/properties/A",
    "/properties/B"
  ],
  "primaryidentifier": [
    "/properties/A",
    "/properties/B"
  ]
}
```


current schema:
```
{
  ...
  "readOnlyProperties": [
    "/properties/A",
    "/properties/B",
    "/properties/C"
  ],
  "primaryidentifier": [
    "/properties/B",
    "/properties/A"
  ]
}
```


older method would give following meta diff:
```
{
  "readOnlyProperties": {
    "added": ["/properties/C"]
  }
}
```

new method would give following meta diff:
```
{
  "readOnlyProperties": {
    "added": ["/properties/C"]
  },
  "primaryIdentifier": {
    "added": ["/properties/B", "/properties/A"],
    "removed": ["/properties/A", "/properties/B"]
  }
}
```


### USER EXPERIENCE

This change also adds a new library [[rich](https://github.com/Textualize/rich)], which helps visualize meta deiff generated between older/newer versions of the schema. 

![Screenshot 2024-04-18 at 1 22 07 PM](https://github.com/aws-cloudformation/resource-schema-guard-rail/assets/56090229/564a7f38-ca37-48fc-83e0-a2a5de572190)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
