### PR TITLE
Added stateful test to verify default values

### DIFF
--- a/docs/BREAKING_CHANGE.md
+++ b/docs/BREAKING_CHANGE.md
@@ -58,3 +58,11 @@
 ||`MI010`|`"cannot remove maximum from properties"`|
 ||`MI011`|`"only NEWLY ADDED properties can have additional maximum constraint"`|
 ||`MI012`|`"new maximum value cannot be less than the old value"`|
+
+
+***
+#### Non CFN Enforced Rules
+| Rule Name   |      Check Id      | Message                                                    |
+|----------|-------------|------------------------------------------------------------|
+|`ensure_default_values_have_not_changed`|`TFDF001`| `"cannot remove default values from properties"`                |
+||`TFDF002`|`"cannot change default values"`|

--- a/src/rpdk/guard_rail/core/stateful.py
+++ b/src/rpdk/guard_rail/core/stateful.py
@@ -89,6 +89,7 @@ native_constructs = {
     "additionalProperties",
     "uniqueItems",
     "dependencies",
+    "default",
 }
 
 

--- a/src/rpdk/guard_rail/rule_library/stateful/schema-stateful-non-cfn-enforced-checks.guard
+++ b/src/rpdk/guard_rail/rule_library/stateful/schema-stateful-non-cfn-enforced-checks.guard
@@ -1,0 +1,20 @@
+rule ensure_default_values_have_not_changed when default exists
+{
+    default.removed !exists
+    <<
+    {
+        "result": "NON_COMPLIANT",
+        "check_id": "TFDF001",
+        "message": "cannot remove default values from properties"
+    }
+    >>
+
+    default.changed !exists
+    <<
+    {
+        "result": "NON_COMPLIANT",
+        "check_id": "TFDF002",
+        "message": "cannot change default values"
+    }
+    >>
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


Adding `"default"` keyword to a set of json native keywords to evaluate. Setting up a non-cfn related rules that evaluate certain structures. It is a placeholder for any external parties to contribute.


sample diff:
```
{
    'default': {
        'changed': [{
            'property': '/properties/SampleProperty,
            'old_value': 'value1',
            'new_value': 'value2'
        }]
    }
}
```

Rules evaluates if default has `changed` or `removed` sub sections.s


```
                                                           Schema Compliance Report
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃                                     Rule Name ┃ Check Id ┃ Message                                   ┃ Path                       ┃  Status ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│               ensure_maxlength_not_contracted │ -        │ -                                         │ -                          │ skipped │
│      ensure_old_property_not_turned_writeonly │ -        │ -                                         │ -                          │ skipped │
│    ensure_property_string_pattern_not_changed │ -        │ -                                         │ -                          │ skipped │
│                ensure_minitems_not_contracted │ -        │ -                                         │ -                          │ skipped │
│                 ensure_minimum_not_contracted │ -        │ -                                         │ -                          │ skipped │
│            ensure_no_more_required_properties │ -        │ -                                         │ -                          │ skipped │
│               ensure_old_property_not_removed │ -        │ -                                         │ -                          │ skipped │
│              ensure_property_type_not_changed │ -        │ -                                         │ -                          │ skipped │
│ ensure_old_property_not_removed_from_readonly │ -        │ -                                         │ -                          │ skipped │
│                       ensure_enum_not_changed │ -        │ -                                         │ -                          │ skipped │
│               ensure_minlength_not_contracted │ -        │ -                                         │ -                          │ skipped │
│                ensure_maxitems_not_contracted │ -        │ -                                         │ -                          │ skipped │
│                 ensure_maximum_not_contracted │ -        │ -                                         │ -                          │ skipped │
│      ensure_old_property_not_turned_immutable │ -        │ -                                         │ -                          │ skipped │
│        ensure_default_values_have_not_changed │ TFDF002  │ cannot change default values              │ /default/changed           │  failed │
└───────────────────────────────────────────────┴──────────┴───────────────────────────────────────────┴────────────────────────────┴─────────┘

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
