### PR TITLE
Fix traversal

### DIFF
--- a/src/rpdk/guard_rail/utils/schema_utils.py
+++ b/src/rpdk/guard_rail/utils/schema_utils.py
@@ -97,6 +97,18 @@ def _fetch_all_paths(schema: Dict):
         else:
             # if combiners are specified then we need to squash variants
             # and iterate over each sub schema
+
+            if _PROPERTIES in definition_replica:
+                nested_properties = definition_replica[_PROPERTIES]
+                while nested_properties:
+                    _prop_name, _prop_definition = nested_properties.popitem()
+                    __traverse(
+                        _prop_name,
+                        _prop_definition,
+                        cur_path + (_prop_name,),
+                        all_paths,
+                    )
+
             if _ALL_OF in definition_replica:
                 for sub_schema in definition_replica[_ALL_OF]:
                     __traverse(prop_name, sub_schema, cur_path, all_paths)
@@ -107,18 +119,7 @@ def _fetch_all_paths(schema: Dict):
                 for sub_schema in definition_replica[_ONE_OF]:
                     __traverse(prop_name, sub_schema, cur_path, all_paths)
             else:
-                # if no combiners were found then we check if there are
-                # nested properties
-                if _PROPERTIES in prop_definition:
-                    nested_properties = definition_replica[_PROPERTIES]
-                    while nested_properties:
-                        _prop_name, _prop_definition = nested_properties.popitem()
-                        __traverse(
-                            _prop_name,
-                            _prop_definition,
-                            cur_path + (_prop_name,),
-                            all_paths,
-                        )
+                pass
 
     resolved_schema = resolve_schema(schema)
     properties_replica = deepcopy(resolved_schema.get(_PROPERTIES, {}))

--- a/tests/unit/utils/data/schemas-for-testing/schema-launch-template.json
+++ b/tests/unit/utils/data/schemas-for-testing/schema-launch-template.json
@@ -1,0 +1,40 @@
+{
+    "definitions": {
+        "LaunchTemplateSpecification": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "LaunchTemplateName": {
+                    "type": "string",
+                    "description": "The name of the launch template. You must specify the LaunchTemplateName or the LaunchTemplateId, but not both."
+                },
+                "LaunchTemplateId": {
+                    "type": "string",
+                    "description": "The ID of the launch template. You must specify the LaunchTemplateName or the LaunchTemplateId, but not both."
+                },
+                "Version": {
+                    "type": "string",
+                    "description": "The version number of the launch template."
+                }
+            },
+            "oneOf": [{
+                    "required": [
+                        "LaunchTemplateName",
+                        "Version"
+                    ]
+                },
+                {
+                    "required": [
+                        "LaunchTemplateId",
+                        "Version"
+                    ]
+                }
+            ]
+        }
+    },
+    "properties": {
+        "LaunchTemplate": {
+            "$ref": "#/definitions/LaunchTemplateSpecification"
+        }
+    }
+}

--- a/tests/unit/utils/data/schemas-for-testing/schema-launch-template.json
+++ b/tests/unit/utils/data/schemas-for-testing/schema-launch-template.json
@@ -17,7 +17,8 @@
                     "description": "The version number of the launch template."
                 }
             },
-            "oneOf": [{
+            "oneOf": [
+                {
                     "required": [
                         "LaunchTemplateName",
                         "Version"

--- a/tests/unit/utils/test_schema_utils.py
+++ b/tests/unit/utils/test_schema_utils.py
@@ -97,6 +97,15 @@ def test_resolve_schema(schema, result):
                 "/properties/Tuples/*/Field/*/NewType",
             },
         ),
+        (
+            "data/schemas-for-testing/schema-launch-template.json",
+            {
+                "/properties/LaunchTemplate",
+                "/properties/LaunchTemplate/LaunchTemplateName",
+                "/properties/LaunchTemplate/LaunchTemplateId",
+                "/properties/LaunchTemplate/Version",
+            },
+        ),
     ],
 )
 def test_add_paths_to_schema(schema, result):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change fixes a bug for traversal algorithm. The issue was when combiners were defined on the same level as `properties`, which would force traversal to go inside combiners. However, it should prioritize properties instead. 

Example:

sample schema
```
{
  "properties": { 
    "Property": {
      "type": "object",
      "properties": {
        "NestedProperty1": {...}
        "NestedProperty2": {...}
      },
      "oneOf": [
        {"required: ["NestedProperty1]},
        {"required: ["NestedProperty2]},
      ]
    }
  }
}
```


<table>
<tr>
<td> Old Result </td><td> New Result </td>
</tr>
<tr>

<td>
    
```
{
    ("Property", )
}
```

</td>

<td>
    

```
{
    ("Property", )
    ("Property", "NestedProperty1")
    ("Property", "NestedProperty2")
}
```

</td>



</tr>
</table>



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
