### PR TITLE
Fixed createOnlyProperties check condition

### DIFF
--- a/src/rpdk/guard_rail/rule_library/core/schema-linter-core-rules.guard
+++ b/src/rpdk/guard_rail/rule_library/core/schema-linter-core-rules.guard
@@ -68,7 +68,7 @@ rule ensure_primary_identifier_is_read_or_create_only when ensure_primary_identi
     }
 
     when readOnlyProperties !exists {
-        createOnlyProperties !exists
+        createOnlyProperties exists
         <<
         {
             "result": "NON_COMPLIANT",

--- a/tests/integ/data/sample-schema-create-only-pid.json
+++ b/tests/integ/data/sample-schema-create-only-pid.json
@@ -1,0 +1,9 @@
+{
+    "createOnlyProperties": [
+        "/properties/PolicyStoreId"
+    ],
+    "primaryIdentifier": [
+        "/properties/PolicyId",
+        "/properties/PolicyStoreId"
+    ]
+}

--- a/tests/integ/runner/test_integ_runner.py
+++ b/tests/integ/runner/test_integ_runner.py
@@ -320,6 +320,47 @@ def test_exec_compliance_stateless(
 
 
 @pytest.mark.parametrize(
+    "collected_schemas,non_compliant_rules",
+    [
+        (
+            collect_schemas(
+                schemas=[
+                    "file:/"
+                    + str(
+                        Path(os.path.dirname(os.path.realpath(__file__))).joinpath(
+                            "../data/sample-schema-create-only-pid.json"
+                        )
+                    )
+                ]
+            ),
+            {
+                "ensure_primary_identifier_is_read_or_create_only": {
+                    GuardRuleResult(
+                        check_id="PID003",
+                        message="primaryIdentifier MUST be either readOnly or createOnly",
+                        path="/primaryIdentifier/0",
+                    )
+                },
+            },
+        ),
+    ],
+)
+def test_exec_compliance_stateless_createOnly_pid_fail(
+    collected_schemas, non_compliant_rules
+):
+    """Test exec_compliance for stateless"""
+    payload: Stateless = Stateless(schemas=collected_schemas, rules=[])
+    compliance_result = exec_compliance(payload)[0]
+
+    # Assert for non-compliant rules
+    for non_compliant_rule, non_compliant_result in non_compliant_rules.items():
+        assert non_compliant_rule in compliance_result.non_compliant
+        assert (
+            non_compliant_result == compliance_result.non_compliant[non_compliant_rule]
+        )
+
+
+@pytest.mark.parametrize(
     "collected_schemas,collected_rules,non_compliant_rules,warning_rules",
     [
         (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixing `PID003` condition to make sure that `createOnlyProperties` if `primaryIdentifier` exists and `readOnlyProperties` do not exist

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
