### PR TITLE
Added new taggable test

### DIFF
--- a/docs/BASIC_LINTING.md
+++ b/docs/BASIC_LINTING.md
@@ -51,6 +51,7 @@
 | | `TAG012` | `"Resource MUST provide 'permissions' if 'tagging.taggable' is true"` |
 | | `TAG013` | `"'tagProperty' MUST specify property defined in the schema"` |
 | | `TAG014` | `"'tagProperty' MUST NOT be a part of 'writeOnlyProperties'"` |
+| | `TAG016` | `"'tagging.taggable' MUST be true when Taging Property is defined in the schema"` |
 
 #### Permissions
 | Rule Name   |      Check Id      |  Message |

--- a/src/rpdk/guard_rail/core/runner.py
+++ b/src/rpdk/guard_rail/core/runner.py
@@ -73,6 +73,7 @@ def __exec_rules__(schema: Dict):
     @logdebug
     def __exec__(rules: str):
         guard_result = cfn_guard_rs.run_checks(schema, rules)
+        tag_path = schema.get("TaggingPath")
 
         def __render_output(evaluation_result: object):
             def __add_item__(rule_name: str, mapping: Mapping, result: Any):
@@ -88,9 +89,13 @@ def __exec_rules__(schema: Dict):
                     try:
                         if check.message:
                             _message_dict = literal_eval(check.message.strip())
+                            _check_id = _message_dict["check_id"]
                             _path = check.path
+                            if _check_id == "TAG016" and tag_path:
+                                _path = tag_path
+
                             rule_result = GuardRuleResult(
-                                check_id=_message_dict["check_id"],
+                                check_id=_check_id,
                                 message=_message_dict["message"],
                                 path=_path,
                             )

--- a/src/rpdk/guard_rail/rule_library/tags/schema-linter-core-tagging-rules.guard
+++ b/src/rpdk/guard_rail/rule_library/tags/schema-linter-core-tagging-rules.guard
@@ -154,4 +154,15 @@ rule ensure_property_tags_exists_v2 when tagging exists {
         }
         >>
     }
+
+    when tagging.taggable == false {
+        TaggingPath !exists
+        <<
+        {
+            "result": "NON_COMPLIANT",
+            "check_id": "TAG016",
+            "message": "`tagging.taggable` MUST be true when Taging Property is defined in the schema"
+        }
+        >>
+    }
 }

--- a/src/rpdk/guard_rail/utils/schema_utils.py
+++ b/src/rpdk/guard_rail/utils/schema_utils.py
@@ -1,6 +1,6 @@
 """Module to handle schema manipulations."""
 from copy import deepcopy
-from typing import Any, Dict, Sequence, Set, Tuple
+from typing import Any, Dict, List, Sequence, Set, Tuple
 
 from jsonschema import RefResolver
 
@@ -143,5 +143,15 @@ def add_paths_to_schema(schema: Dict):
     Returns:
         Dict: schema with added paths
     """
-    schema["paths"] = _fetch_all_paths(schema)
+    paths = _fetch_all_paths(schema)
+    schema["paths"] = paths
+    _add_tag_property(paths, schema)
     return schema
+
+
+def _add_tag_property(paths: List[str], schema: Dict):
+    for path in paths:
+        property_name = path.split("/")[-1]
+        if "Tag" in property_name:
+            schema["TaggingPath"] = path
+            return

--- a/tests/integ/data/schema-not-taggable-with-tags.json
+++ b/tests/integ/data/schema-not-taggable-with-tags.json
@@ -1,0 +1,42 @@
+{
+    "properties": {
+        "StageDescription": {
+            "$ref": "#/definitions/StageDescription"
+        }
+    },
+    "definitions": {
+        "StageDescription": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Tags": {
+                    "type": "array",
+                    "uniqueItems": false,
+                    "insertionOrder": false,
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    }
+                }
+            }
+        },
+        "Tag": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Value",
+                "Key"
+            ]
+        }
+    },
+    "tagging": {
+        "taggable": false
+    }
+}

--- a/tests/integ/runner/test_integ_runner.py
+++ b/tests/integ/runner/test_integ_runner.py
@@ -481,6 +481,48 @@ def test_exec_compliance_stateless_tagging_permission_specified(
 
 
 @pytest.mark.parametrize(
+    "collected_schemas,collected_rules,non_compliant_rules",
+    [
+        (
+            collect_schemas(
+                schemas=[
+                    "file:/"
+                    + str(
+                        Path(os.path.dirname(os.path.realpath(__file__))).joinpath(
+                            "../data/schema-not-taggable-with-tags.json"
+                        )
+                    )
+                ]
+            ),
+            [],
+            {
+                "ensure_property_tags_exists_v2": {
+                    GuardRuleResult(
+                        check_id="TAG016",
+                        message="`tagging.taggable` MUST be true when Taging Property is defined in the schema",
+                        path="/properties/StageDescription/Tags",
+                    ),
+                }
+            },
+        ),
+    ],
+)
+def test_exec_compliance_stateless_not_taggable_with_tags(
+    collected_schemas, collected_rules, non_compliant_rules
+):
+    """Test exec_compliance for stateless"""
+    payload: Stateless = Stateless(schemas=collected_schemas, rules=collected_rules)
+    compliance_result = exec_compliance(payload)[0]
+
+    # Assert for non-compliant rules
+    for non_compliant_rule, non_compliant_result in non_compliant_rules.items():
+        assert non_compliant_rule in compliance_result.non_compliant
+        assert (
+            non_compliant_result == compliance_result.non_compliant[non_compliant_rule]
+        )
+
+
+@pytest.mark.parametrize(
     "previous_schema, current_schema, collected_rules,non_compliant_rules,warning_rules",
     [
         (

--- a/tests/unit/utils/data/schemas-for-testing/schema-launch-template.json
+++ b/tests/unit/utils/data/schemas-for-testing/schema-launch-template.json
@@ -1,5 +1,35 @@
 {
     "definitions": {
+        "Description": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Tags": {
+                    "type": "array",
+                    "uniqueItems": false,
+                    "insertionOrder": false,
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    }
+                }
+            }
+        },
+        "Tag": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Value",
+                "Key"
+            ]
+        },
         "LaunchTemplateSpecification": {
             "type": "object",
             "additionalProperties": false,
@@ -36,6 +66,9 @@
     "properties": {
         "LaunchTemplate": {
             "$ref": "#/definitions/LaunchTemplateSpecification"
+        },
+        "Description": {
+            "$ref": "#/definitions/Description"
         }
     }
 }

--- a/tests/unit/utils/test_schema_utils.py
+++ b/tests/unit/utils/test_schema_utils.py
@@ -104,6 +104,10 @@ def test_resolve_schema(schema, result):
                 "/properties/LaunchTemplate/LaunchTemplateName",
                 "/properties/LaunchTemplate/LaunchTemplateId",
                 "/properties/LaunchTemplate/Version",
+                "/properties/Description",
+                "/properties/Description/Tags",
+                "/properties/Description/Tags/*/Key",
+                "/properties/Description/Tags/*/Value",
             },
         ),
     ],
@@ -118,3 +122,34 @@ def test_add_paths_to_schema(schema, result):
     )
     schema_with_paths = add_paths_to_schema(collected_schemas_to_resolve[0])
     assert set(schema_with_paths["paths"]) == result
+
+
+@pytest.mark.parametrize(
+    "schema,result",
+    [
+        (
+            "data/schemas-for-testing/schema-launch-template.json",
+            {
+                "/properties/LaunchTemplate",
+                "/properties/LaunchTemplate/LaunchTemplateName",
+                "/properties/LaunchTemplate/LaunchTemplateId",
+                "/properties/LaunchTemplate/Version",
+                "/properties/Description",
+                "/properties/Description/Tags",
+                "/properties/Description/Tags/*/Key",
+                "/properties/Description/Tags/*/Value",
+            },
+        )
+    ],
+)
+def test_add_tag_path(schema, result):
+    """Unit test to verify that schema has tag property identified"""
+    collected_schemas_to_resolve = collect_schemas(
+        schemas=[
+            "file:/"
+            + str(Path(os.path.dirname(os.path.realpath(__file__))).joinpath(schema))
+        ]
+    )
+    schema_with_paths = add_paths_to_schema(collected_schemas_to_resolve[0])
+    assert "TaggingPath" in schema_with_paths
+    assert schema_with_paths["TaggingPath"] == "/properties/Description/Tags"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This commit adds a new test. This test scans all fetched properties (traversed during schema scan) and identifies a property that has `*Tag*` in it. This will be classified as tagging property, thus `tagging.taggable` **MUST** be `True`. Otherwise test fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
