### PR TITLE
Add schema diff to the output

### DIFF
--- a/src/rpdk/guard_rail/core/data_types.py
+++ b/src/rpdk/guard_rail/core/data_types.py
@@ -19,7 +19,7 @@ Typical usage example:
         )
 """
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from rich.console import Console
 from rich.table import Table
@@ -78,12 +78,14 @@ class GuardRuleSetResult:
         non_compliant: rules, that schema(s) failed
         warning: rules, that schema(s) failed but it's not a hard requirement
         skipped: rules, that are not applicable to the schema(s)
+        schema_difference: optional dictionary containing schema difference
     """
 
     compliant: List[str] = field(default_factory=list)
     non_compliant: Dict[str, List[GuardRuleResult]] = field(default_factory=dict)
     warning: Dict[str, List[GuardRuleResult]] = field(default_factory=dict)
     skipped: List[str] = field(default_factory=list)
+    schema_difference: Optional[dict] = field(default_factory=dict)
 
     def merge(self, guard_ruleset_result: Any):
         """Merges the result into a nice mutual set.

--- a/src/rpdk/guard_rail/core/runner.py
+++ b/src/rpdk/guard_rail/core/runner.py
@@ -183,12 +183,13 @@ def _(payload):
             output = schema_exec(rules)
         return output
 
-    schema_to_execute = __exec_rules__(
-        schema=schema_diff(
-            previous_json=payload.previous_schema, current_json=payload.current_schema
-        )
+    schema_difference = schema_diff(
+        previous_json=payload.previous_schema, current_json=payload.current_schema
     )
+
+    schema_to_execute = __exec_rules__(schema=schema_difference)
     output = __execute__(schema_exec=schema_to_execute, ruleset=ruleset)
+    output.schema_difference = schema_difference
     compliance_output.append(output)
 
     return compliance_output

--- a/tests/unit/core/test_data_types.py
+++ b/tests/unit/core/test_data_types.py
@@ -37,5 +37,5 @@ def test_success_result_str():
                 }
             )
         )
-        == "GuardRuleSetResult(compliant=[], non_compliant={'ensure_old_property_not_turned_immutable': {GuardRuleResult(check_id='MI007', message='cannot remove minimum from properties', path='/minimum/removed')}}, warning={}, skipped=[])"  # pylint: disable=C0301
+        == "GuardRuleSetResult(compliant=[], non_compliant={'ensure_old_property_not_turned_immutable': {GuardRuleResult(check_id='MI007', message='cannot remove minimum from properties', path='/minimum/removed')}}, warning={}, skipped=[], schema_difference={})"  # pylint: disable=C0301
     )


### PR DESCRIPTION
*Issue #, if available:*

The schema diff is not present in the output

*Description of changes:*

Add schema diff to the output.

Sample Input:

previous_schema = 
```{
    "definitions": {
        "Workgroup": {
            "additionalProperties": false,
            "properties": {},
            "type": "object"
        }
    },
    "properties": {
        "Workgroup": {
            "$ref": "#/definitions/Workgroup"
        }
    },
    "readOnlyProperties": [
        "/properties/Workgroup"
    ]
}
```

new_schema = 
```{
    "definitions": {
        "Workgroup": {
            "additionalProperties": false,
            "properties": {},
            "type": "object"
        },
        "Newfield": {
            "additionalProperties": false,
            "properties": {},
            "type": "object"
        }
    },
    "properties": {
        "Workgroup": {
            "$ref": "#/definitions/Workgroup"
        },
        "Newfield": {
            "$ref": "#/definitions/Newfield"
        }
    },
    "readOnlyProperties": [
        "/properties/Workgroup",
        "/properties/Newfield"
    ]
}
```

Sample output =>  guard-rail --schema previous_schema new_schema --stateful

```
[GuardRuleSetResult(compliant=['ensure_old_property_not_removed_from_readonly', 'ensure_old_property_not_removed'], non_compliant={}, warning={}, skipped=['ensure_default_values_have_not_changed', 'ensure_maxitems_not_contracted', 'ensure_maximum_not_contracted', 'ensure_old_property_not_turned_immutable', 'ensure_minitems_not_contracted', 'ensure_maxlength_not_contracted', 'ensure_minimum_not_contracted', 'ensure_no_more_required_properties', 'ensure_enum_not_changed', 'ensure_primary_identifier_not_changed', 'ensure_property_type_not_changed', 'ensure_minlength_not_contracted', 'ensure_old_property_not_turned_writeonly', 'ensure_property_string_pattern_not_changed'], schema_difference={'properties': {'added': ['/properties/Newfield']}, 'readOnlyProperties': {'added': ['/properties/Newfield']}})]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
