### PR TITLE
Update schema diff to match schema format for customer set values

### DIFF
--- a/src/rpdk/guard_rail/core/stateful.py
+++ b/src/rpdk/guard_rail/core/stateful.py
@@ -165,6 +165,7 @@ def _cast_path(value: str):
     """cast the path of the change to process constructs"""
     pattern = r"(?<=\[)'?([\s\S]+?)'?(?=\])"
     value = value.replace("items']['properties", "*")
+    value = value.replace("]['properties'][", "][")
     value = re.sub(r"[0-9]+]", "", value)
     return re.findall(pattern, value)
 

--- a/tests/unit/core/test_stateful.py
+++ b/tests/unit/core/test_stateful.py
@@ -255,7 +255,7 @@ from rpdk.guard_rail.core.stateful import schema_diff
             {
                 "relationshipRef": {
                     "removed": [
-                        "/properties/Configuration/properties/ExecuteCommandConfiguration/properties/KmsKeyId"
+                        "/properties/Configuration/ExecuteCommandConfiguration/KmsKeyId"
                     ]
                 },
                 "type": {
@@ -271,7 +271,7 @@ from rpdk.guard_rail.core.stateful import schema_diff
             {
                 "relationshipRef": {
                     "added": [
-                        "/properties/Configuration/properties/ExecuteCommandConfiguration/properties/KmsKeyId"
+                        "/properties/Configuration/ExecuteCommandConfiguration/KmsKeyId"
                     ]
                 },
                 "type": {
@@ -541,13 +541,13 @@ from rpdk.guard_rail.core.stateful import schema_diff
                 "properties": {
                     "added": [
                         "/properties/ECSEndpoint",
-                        "/properties/Configuration/properties/ExecuteCommandConfiguration/properties/Logging",
+                        "/properties/Configuration/ExecuteCommandConfiguration/Logging",
                     ]
                 },
                 "relationshipRef": {
                     "added": [
                         "/properties/DefaultCapacityProviderStrategy/*/CapacityProvider",
-                        "/properties/Configuration/properties/ExecuteCommandConfiguration/properties/KmsKeyId",
+                        "/properties/Configuration/ExecuteCommandConfiguration/KmsKeyId",
                     ]
                 },
                 "insertionOrder": {"removed": ["/properties/ClusterSettings"]},
@@ -556,13 +556,13 @@ from rpdk.guard_rail.core.stateful import schema_diff
                 "properties": {
                     "removed": [
                         "/properties/ECSEndpoint",
-                        "/properties/Configuration/properties/ExecuteCommandConfiguration/properties/Logging",
+                        "/properties/Configuration/ExecuteCommandConfiguration/Logging",
                     ]
                 },
                 "relationshipRef": {
                     "removed": [
                         "/properties/DefaultCapacityProviderStrategy/*/CapacityProvider",
-                        "/properties/Configuration/properties/ExecuteCommandConfiguration/properties/KmsKeyId",
+                        "/properties/Configuration/ExecuteCommandConfiguration/KmsKeyId",
                     ]
                 },
                 "insertionOrder": {"added": ["/properties/ClusterSettings"]},


### PR DESCRIPTION
*Issue #, if available:*

SGR evaluates backward compatibility on readOnlyProperties - only new properties can be added to readOnly
SGR incorrectly fails on new properties being added to readOnly.

Example failure:
```Python
#Old schema
{
    "definitions": {
        "Workgroup": {
            "additionalProperties": false,
            "properties": {},
            "type": "object"
        }
    },
    "properties": {
        "Workgroup": {
            "$ref": "#/definitions/Workgroup"
        }
    },
    "readOnlyProperties": [
        "/properties/Workgroup"
    ]
}

# New schema
{
    "definitions": {
        "Workgroup": {
            "additionalProperties": false,
            "properties": {
                "MaxCapacity": {
                    "type": "integer"
                }
            },
            "type": "object"
        }
    },
    "properties": {
        "Workgroup": {
            "$ref": "#/definitions/Workgroup",
            "description": "Definition for workgroup resource"
        }
    },
    "readOnlyProperties": [
        "/properties/Workgroup",
        "/properties/Workgroup/MaxCapacity"
    ]
}

#Generated diff
{
    'description': {
        'added': ['/properties/Workgroup']
    },
    'properties': {
        'added': ['/properties/Workgroup/properties/MaxCapacity']
    },
    'readOnlyProperties': {
        'added': ['/properties/Workgroup/MaxCapacity']
    }
}
```

SGR rules are not be able to handle the mapping from `/properties/Workgroup/MaxCapacity` to `/properties/Workgroup/properties/MaxCapacity`.  This causes schema check failure when changes are allowed. 

The above schema will cause this rule to fail: 
```
let newProps = properties.added
rule ensure_old_property_not_removed_from_readonly when readOnlyProperties exists
{
    when properties.added exists {
        readOnlyProperties.added[*] {
            this IN %newProps
            <<
            {
                "result": "NON_COMPLIANT",
                "check_id": "PR004",
                "message": "Only NEWLY ADDED properties can be marked as readOnlyProperties"
            }
            >>
        }
    }

. . . 
```

*Description of changes:*

Change is only one line:
```Python
value = value.replace("]['properties'][", "][")
```

This is placed within the `_cast_path` method which is called on every path found within the `DeepDiff` to process them from form:
`root['properties']['Workgroup']['properties']['MaxCapacity']` -> `properties/Workgroup/properties/MaxCapacity`

By replacing all occurrences of `]['properties'][` with `][`we shrink the input and remove all nested properties within the path returned by the 'DeepDiff' operation. 

Unit tests updated to correct expected path output for schema evaluation. 

Testing done locally though integration / unit tests. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
