### PR TITLE
Add guard rule to enforce tag property is not create only

### DIFF
--- a/src/rpdk/guard_rail/rule_library/tags/schema-linter-core-tagging-rules.guard
+++ b/src/rpdk/guard_rail/rule_library/tags/schema-linter-core-tagging-rules.guard
@@ -153,16 +153,16 @@ rule ensure_property_tags_exists_v2 when tagging exists {
                     "message": "`tagProperty` MUST NOT be a part of `createOnlyProperties`"
                 }
                 >>
-
-                tagging.tagProperty !IN createOnlyProperties
-                tagging.tagUpdatable == false
-                <<
-                {
-                    "result": "WARNING",
-                    "check_id": "TAG018",
-                    "message": "`tagProperty` MUST NOT be a part of `createOnlyProperties` when `tagUpdatable` is true"
+                when tagging.tagProperty IN createOnlyProperties {
+                    tagging.tagUpdatable == false
+                    <<
+                    {
+                        "result": "WARNING",
+                        "check_id": "TAG018",
+                        "message": "`tagProperty` MUST NOT be a part of `createOnlyProperties` when `tagUpdatable` is true"
+                    }
+                    >>
                 }
-                >>
             }
         }
         tagging.permissions exists

--- a/src/rpdk/guard_rail/rule_library/tags/schema-linter-core-tagging-rules.guard
+++ b/src/rpdk/guard_rail/rule_library/tags/schema-linter-core-tagging-rules.guard
@@ -144,6 +144,26 @@ rule ensure_property_tags_exists_v2 when tagging exists {
                 }
                 >>
             }
+            when createOnlyProperties exists {
+                tagging.tagProperty !IN createOnlyProperties
+                <<
+                {
+                    "result": "WARNING",
+                    "check_id": "TAG017",
+                    "message": "`tagProperty` MUST NOT be a part of `createOnlyProperties`"
+                }
+                >>
+
+                tagging.tagProperty !IN createOnlyProperties
+                tagging.tagUpdatable == false
+                <<
+                {
+                    "result": "WARNING",
+                    "check_id": "TAG018",
+                    "message": "`tagProperty` MUST NOT be a part of `createOnlyProperties` when `tagUpdatable` is true"
+                }
+                >>
+            }
         }
         tagging.permissions exists
         <<
@@ -161,7 +181,7 @@ rule ensure_property_tags_exists_v2 when tagging exists {
         {
             "result": "NON_COMPLIANT",
             "check_id": "TAG016",
-            "message": "`tagging.taggable` MUST be true when Taging Property is defined in the schema"
+            "message": "`tagging.taggable` MUST be true when Tagging Property is defined in the schema"
         }
         >>
     }

--- a/tests/integ/data/schema-tag-property-createonly-updatable.json
+++ b/tests/integ/data/schema-tag-property-createonly-updatable.json
@@ -1,0 +1,16 @@
+{
+    "properties": {
+        "Tags": {},
+        "Arn": {}
+    },
+    "createOnlyProperties": [
+        "/properties/Tags"
+    ],
+    "tagging": {
+        "taggable": true,
+        "tagOnCreate": true,
+        "tagUpdatable": true,
+        "cloudFormationSystemTags": false,
+        "tagProperty": "/properties/Tags"
+    }
+}

--- a/tests/integ/data/schema-tag-property-createonly.json
+++ b/tests/integ/data/schema-tag-property-createonly.json
@@ -1,0 +1,16 @@
+{
+    "properties": {
+        "Tags": {},
+        "Arn": {}
+    },
+    "createOnlyProperties": [
+        "/properties/Tags"
+    ],
+    "tagging": {
+        "taggable": true,
+        "tagOnCreate": true,
+        "tagUpdatable": false,
+        "cloudFormationSystemTags": false,
+        "tagProperty": "/properties/Tags"
+    }
+}

--- a/tests/integ/runner/test_integ_runner.py
+++ b/tests/integ/runner/test_integ_runner.py
@@ -291,6 +291,73 @@ from rpdk.guard_rail.utils.arg_handler import collect_schemas
                     "file:/"
                     + str(
                         Path(os.path.dirname(os.path.realpath(__file__))).joinpath(
+                            "../data/schema-tag-property-createonly-updatable.json"
+                        )
+                    )
+                ]
+            ),
+            [],
+            {
+                "ensure_property_tags_exists_v2": {
+                    GuardRuleResult(
+                        check_id="TAG012",
+                        message="Resource MUST provide `permissions` if `tagging.taggable` is true",
+                        path="",
+                    ),
+                },
+            },
+            {
+                "ensure_property_tags_exists_v2": {
+                    GuardRuleResult(
+                        check_id="TAG017",
+                        message="`tagProperty` MUST NOT be a part of `createOnlyProperties`",
+                        path="/tagging/tagProperty",
+                    ),
+                    GuardRuleResult(
+                        check_id="TAG018",
+                        message="`tagProperty` MUST NOT be a part of `createOnlyProperties` when `tagUpdatable` is true",
+                        path="/tagging/tagUpdatable",
+                    ),
+                },
+            },
+        ),
+        (
+            collect_schemas(
+                schemas=[
+                    "file:/"
+                    + str(
+                        Path(os.path.dirname(os.path.realpath(__file__))).joinpath(
+                            "../data/schema-tag-property-createonly.json"
+                        )
+                    )
+                ]
+            ),
+            [],
+            {
+                "ensure_property_tags_exists_v2": {
+                    GuardRuleResult(
+                        check_id="TAG012",
+                        message="Resource MUST provide `permissions` if `tagging.taggable` is true",
+                        path="",
+                    ),
+                },
+            },
+            {
+                "ensure_property_tags_exists_v2": {
+                    GuardRuleResult(
+                        check_id="TAG017",
+                        message="`tagProperty` MUST NOT be a part of `createOnlyProperties`",
+                        path="/tagging/tagProperty",
+                    ),
+                },
+            },
+        ),
+        (
+            collect_schemas(
+                schemas=[
+                    "file:/"
+                    + str(
+                        Path(os.path.dirname(os.path.realpath(__file__))).joinpath(
                             "../data/schema-primary-id-writeonly.json"
                         )
                     )
@@ -499,7 +566,7 @@ def test_exec_compliance_stateless_tagging_permission_specified(
                 "ensure_property_tags_exists_v2": {
                     GuardRuleResult(
                         check_id="TAG016",
-                        message="`tagging.taggable` MUST be true when Taging Property is defined in the schema",
+                        message="`tagging.taggable` MUST be true when Tagging Property is defined in the schema",
                         path="/properties/StageDescription/Tags",
                     ),
                 }


### PR DESCRIPTION
*Issue #, if available:*

Tags must be updatable. Therefore, they must not be a create only property of a resource schema. If they are allowed to be create only for a given resource. Tag updatable must be false.

*Description of changes:*

Added two guard rules to assert that tagProperty cannot be within the create only property list. If it is a create only property, then tagging updatable must be false. 

Rules set as warning initially. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
