### PR TITLE
Add rule to validate AWS:* Prefix Resource Tags are blocked

### DIFF
--- a/src/rpdk/guard_rail/core/runner.py
+++ b/src/rpdk/guard_rail/core/runner.py
@@ -91,10 +91,7 @@ def __exec_rules__(schema: Dict):
                             _message_dict = literal_eval(check.message.strip())
                             _check_id = _message_dict["check_id"]
                             _path = check.path
-                            if _check_id == "TAG016" and tag_path:
-                                _path = tag_path
-
-                            if _check_id == "TAG019" and tag_path:
+                            if _check_id in ("TAG016", "TAG019") and tag_path:
                                 _path = tag_path
 
                             rule_result = GuardRuleResult(

--- a/src/rpdk/guard_rail/core/runner.py
+++ b/src/rpdk/guard_rail/core/runner.py
@@ -94,6 +94,9 @@ def __exec_rules__(schema: Dict):
                             if _check_id == "TAG016" and tag_path:
                                 _path = tag_path
 
+                            if _check_id == "TAG019" and tag_path:
+                                _path = tag_path
+
                             rule_result = GuardRuleResult(
                                 check_id=_check_id,
                                 message=_message_dict["message"],

--- a/src/rpdk/guard_rail/rule_library/tags/schema-linter-core-tagging-rules.guard
+++ b/src/rpdk/guard_rail/rule_library/tags/schema-linter-core-tagging-rules.guard
@@ -188,7 +188,7 @@ rule ensure_property_tags_exists_v2 when tagging exists {
 }
 
 rule ensure_aws_system_tags_blocked when TaggingPath exists {
-    TaggingKey exists
+    TaggingKeyPattern exists
     <<
     {
         "result": "WARNING",
@@ -197,8 +197,8 @@ rule ensure_aws_system_tags_blocked when TaggingPath exists {
     }
     >>
 
-    when TaggingKey exists {
-        TaggingKey.pattern exists
+    when TaggingKeyPattern exists {
+        TaggingKeyPattern == true
         <<
         {
             "result": "WARNING",
@@ -206,16 +206,5 @@ rule ensure_aws_system_tags_blocked when TaggingPath exists {
             "message": "Tagging Property should have pattern specified to block aws: prefix tags when Tagging Property is defined in the schema"
         }
         >>
-
-        when TaggingKey.pattern exists {
-            TaggingKey.pattern == "^(?i)(?!aws:).*$"
-            <<
-            {
-                "result": "WARNING",
-                "check_id": "TAG019",
-                "message": "Tagging Property should have pattern specified to block aws: prefix tags when Tagging Property is defined in the schema"
-            }
-            >>
-        }
     }
 }

--- a/src/rpdk/guard_rail/rule_library/tags/schema-linter-core-tagging-rules.guard
+++ b/src/rpdk/guard_rail/rule_library/tags/schema-linter-core-tagging-rules.guard
@@ -186,3 +186,36 @@ rule ensure_property_tags_exists_v2 when tagging exists {
         >>
     }
 }
+
+rule ensure_aws_system_tags_blocked when TaggingPath exists {
+    TaggingKey exists
+    <<
+    {
+        "result": "WARNING",
+        "check_id": "TAG019",
+        "message": "Tagging Property should have pattern specified to block aws: prefix tags when Tagging Property is defined in the schema"
+    }
+    >>
+
+    when TaggingKey exists {
+        TaggingKey.pattern exists
+        <<
+        {
+            "result": "WARNING",
+            "check_id": "TAG019",
+            "message": "Tagging Property should have pattern specified to block aws: prefix tags when Tagging Property is defined in the schema"
+        }
+        >>
+
+        when TaggingKey.pattern exists {
+            TaggingKey.pattern == "^(?i)(?!aws:).*$"
+            <<
+            {
+                "result": "WARNING",
+                "check_id": "TAG019",
+                "message": "Tagging Property should have pattern specified to block aws: prefix tags when Tagging Property is defined in the schema"
+            }
+            >>
+        }
+    }
+}

--- a/src/rpdk/guard_rail/utils/schema_utils.py
+++ b/src/rpdk/guard_rail/utils/schema_utils.py
@@ -176,3 +176,15 @@ def _add_tagging_key(schema: Dict):
             if "properties" in items_schema and "Key" in items_schema["properties"]:
                 schema["TaggingKey"] = items_schema["properties"]["Key"]
                 return
+
+        if tags_schema.get("type") == "object":
+
+            def _get_first_pattern_key(schema: Dict) -> str:
+                pattern_properties = schema.get("patternProperties", {})
+                if pattern_properties:
+                    return next(iter(pattern_properties))
+                return None
+
+            if "patternProperties" in tags_schema:
+                schema["TaggingKey"] = {"pattern": _get_first_pattern_key(tags_schema)}
+                return

--- a/src/rpdk/guard_rail/utils/schema_utils.py
+++ b/src/rpdk/guard_rail/utils/schema_utils.py
@@ -197,6 +197,7 @@ def _is_tag_key_pattern_match(tag_key: str):
     _AWS_PREFIX_TAG = "aws:"
     if "pattern" in tag_key:
         tag_key_pattern = tag_key["pattern"]
-        is_blocked = not re.match(tag_key_pattern, _AWS_PREFIX_TAG)
-        return is_blocked
+        if isinstance(tag_key_pattern, str):
+            is_blocked = not re.match(tag_key_pattern, _AWS_PREFIX_TAG)
+            return is_blocked
     return False

--- a/tests/integ/data/schema-tag-property-system-tag-incomplete-pattern.json
+++ b/tests/integ/data/schema-tag-property-system-tag-incomplete-pattern.json
@@ -1,0 +1,27 @@
+{
+    "definitions": {
+        "Tags": {
+            "type": "object",
+            "properties": {
+                "Key": {
+                    "type": "string",
+                    "pattern": ""
+                },
+                "Value": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "properties": {
+        "Tags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Tags"
+            }
+        }
+    },
+    "tagging": {
+        "tagProperty": "/properties/Tags"
+    }
+}

--- a/tests/integ/data/schema-tag-property-system-tag-nested.json
+++ b/tests/integ/data/schema-tag-property-system-tag-nested.json
@@ -1,0 +1,36 @@
+{
+    "definitions": {
+        "Description": {
+            "type": "object",
+            "properties": {
+                "Tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    }
+                }
+            }
+        },
+        "Tag": {
+            "type": "object",
+            "properties": {
+                "Key": {
+                    "type": "string",
+                    "pattern": ""
+                },
+                "Value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Value",
+                "Key"
+            ]
+        }
+    },
+    "properties": {
+        "Description": {
+            "$ref": "#/definitions/Description"
+        }
+    }
+}

--- a/tests/integ/data/schema-tag-property-system-tag-no-pattern.json
+++ b/tests/integ/data/schema-tag-property-system-tag-no-pattern.json
@@ -1,0 +1,26 @@
+{
+    "definitions": {
+        "Tags": {
+            "type": "object",
+            "properties": {
+                "Key": {
+                    "type": "string"
+                },
+                "Value": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "properties": {
+        "Tags": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Tags"
+            }
+        }
+    },
+    "tagging": {
+        "tagProperty": "/properties/Tags"
+    }
+}

--- a/tests/integ/runner/test_integ_runner.py
+++ b/tests/integ/runner/test_integ_runner.py
@@ -375,6 +375,54 @@ from rpdk.guard_rail.utils.arg_handler import collect_schemas
             },
             {},
         ),
+        (
+            collect_schemas(
+                schemas=[
+                    "file:/"
+                    + str(
+                        Path(os.path.dirname(os.path.realpath(__file__))).joinpath(
+                            "../data/schema-tag-property-system-tag-no-pattern.json"
+                        )
+                    )
+                ]
+            ),
+            [],
+            {},
+            {
+                "ensure_aws_system_tags_blocked": {
+                    GuardRuleResult(
+                        check_id="TAG019",
+                        message="Tagging Property should have pattern specified to block aws: prefix tags"
+                        + " when Tagging Property is defined in the schema",
+                        path="/properties/Tags",
+                    ),
+                },
+            },
+        ),
+        (
+            collect_schemas(
+                schemas=[
+                    "file:/"
+                    + str(
+                        Path(os.path.dirname(os.path.realpath(__file__))).joinpath(
+                            "../data/schema-tag-property-system-tag-incomplete-pattern.json"
+                        )
+                    )
+                ]
+            ),
+            [],
+            {},
+            {
+                "ensure_aws_system_tags_blocked": {
+                    GuardRuleResult(
+                        check_id="TAG019",
+                        message="Tagging Property should have pattern specified to block aws: prefix tags"
+                        + " when Tagging Property is defined in the schema",
+                        path="/properties/Tags",
+                    ),
+                },
+            },
+        ),
     ],
 )
 def test_exec_compliance_stateless(

--- a/tests/integ/runner/test_integ_runner.py
+++ b/tests/integ/runner/test_integ_runner.py
@@ -423,6 +423,30 @@ from rpdk.guard_rail.utils.arg_handler import collect_schemas
                 },
             },
         ),
+        (
+            collect_schemas(
+                schemas=[
+                    "file:/"
+                    + str(
+                        Path(os.path.dirname(os.path.realpath(__file__))).joinpath(
+                            "../data/schema-tag-property-system-tag-nested.json"
+                        )
+                    )
+                ]
+            ),
+            [],
+            {},
+            {
+                "ensure_aws_system_tags_blocked": {
+                    GuardRuleResult(
+                        check_id="TAG019",
+                        message="Tagging Property should have pattern specified to block aws: prefix tags"
+                        + " when Tagging Property is defined in the schema",
+                        path="/properties/Description/Tags",
+                    ),
+                },
+            },
+        ),
     ],
 )
 def test_exec_compliance_stateless(

--- a/tests/unit/utils/data/schemas-for-testing/schema-with-nonarrary-tags.json
+++ b/tests/unit/utils/data/schemas-for-testing/schema-with-nonarrary-tags.json
@@ -25,7 +25,7 @@
             "description": "This resource type use map for Tags, suggest to use List of Tag",
             "additionalProperties": false,
             "patternProperties": {
-                ".*": {
+                "^[A-Za-z][A-Za-z0-9-]*$": {
                     "type": "string"
                 }
             }

--- a/tests/unit/utils/data/schemas-for-testing/schema-with-nonarrary-tags.json
+++ b/tests/unit/utils/data/schemas-for-testing/schema-with-nonarrary-tags.json
@@ -1,0 +1,106 @@
+{
+    "typeName": "AWS::ApiGatewayV2::VpcLink",
+    "description": "Resource Type definition for AWS::ApiGatewayV2::VpcLink",
+    "additionalProperties": false,
+    "properties": {
+        "VpcLinkId": {
+            "type": "string"
+        },
+        "SubnetIds": {
+            "type": "array",
+            "uniqueItems": false,
+            "items": {
+                "type": "string"
+            }
+        },
+        "SecurityGroupIds": {
+            "type": "array",
+            "uniqueItems": false,
+            "items": {
+                "type": "string"
+            }
+        },
+        "Tags": {
+            "type": "object",
+            "description": "This resource type use map for Tags, suggest to use List of Tag",
+            "additionalProperties": false,
+            "patternProperties": {
+                ".*": {
+                    "type": "string"
+                }
+            }
+        },
+        "Name": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "SubnetIds",
+        "Name"
+    ],
+    "createOnlyProperties": [
+        "/properties/SecurityGroupIds",
+        "/properties/SubnetIds"
+    ],
+    "primaryIdentifier": [
+        "/properties/VpcLinkId"
+    ],
+    "readOnlyProperties": [
+        "/properties/VpcLinkId"
+    ],
+    "tagging": {
+        "taggable": true,
+        "tagOnCreate": true,
+        "tagUpdatable": true,
+        "cloudFormationSystemTags": true,
+        "tagProperty": "/properties/Tags"
+    },
+    "handlers": {
+        "create": {
+            "permissions": [
+                "apigateway:POST",
+                "apigateway:GET",
+                "apigateway:TagResource",
+                "iam:CreateServiceLinkedRole",
+                "iam:DeleteServiceLinkedRole",
+                "iam:GetServiceLinkedRoleDeletionStatus"
+            ]
+        },
+        "update": {
+            "permissions": [
+                "apigateway:PATCH",
+                "apigateway:GET",
+                "apigateway:TagResource",
+                "apigateway:unTagResource",
+                "iam:CreateServiceLinkedRole",
+                "iam:DeleteServiceLinkedRole",
+                "iam:GetServiceLinkedRoleDeletionStatus"
+            ]
+        },
+        "read": {
+            "permissions": [
+                "apigateway:GET",
+                "iam:CreateServiceLinkedRole",
+                "iam:DeleteServiceLinkedRole",
+                "iam:GetServiceLinkedRoleDeletionStatus"
+            ]
+        },
+        "delete": {
+            "permissions": [
+                "apigateway:GET",
+                "apigateway:DELETE",
+                "iam:CreateServiceLinkedRole",
+                "iam:DeleteServiceLinkedRole",
+                "iam:GetServiceLinkedRoleDeletionStatus"
+            ]
+        },
+        "list": {
+            "permissions": [
+                "apigateway:GET",
+                "iam:CreateServiceLinkedRole",
+                "iam:DeleteServiceLinkedRole",
+                "iam:GetServiceLinkedRoleDeletionStatus"
+            ]
+        }
+    }
+}

--- a/tests/unit/utils/test_schema_utils.py
+++ b/tests/unit/utils/test_schema_utils.py
@@ -156,21 +156,21 @@ def test_add_tag_path(schema, result):
 
 
 @pytest.mark.parametrize(
-    "schema,tagpath, tagkey",
+    "schema, tagpath, tag_key_pattern_match",
     [
         (
             "data/schemas-for-testing/schema-launch-template.json",
             "/properties/Description/Tags",
-            {"type": "string"},
+            False,
         ),
         (
             "data/schemas-for-testing/schema-with-nonarrary-tags.json",
             "/properties/Tags",
-            {"pattern": ".*"},
+            True,
         ),
     ],
 )
-def test_add_tag_key(schema, tagpath, tagkey):
+def test_add_tag_key(schema, tagpath, tag_key_pattern_match):
     """Unit test to verify that schema has tag key definition"""
     collected_schemas_to_resolve = collect_schemas(
         schemas=[
@@ -181,5 +181,5 @@ def test_add_tag_key(schema, tagpath, tagkey):
     schema_with_paths = add_paths_to_schema(collected_schemas_to_resolve[0])
     assert "TaggingPath" in schema_with_paths
     assert schema_with_paths["TaggingPath"] == tagpath
-    assert "TaggingKey" in schema_with_paths
-    assert schema_with_paths["TaggingKey"] == tagkey
+    assert "TaggingKeyPattern" in schema_with_paths
+    assert schema_with_paths["TaggingKeyPattern"] is tag_key_pattern_match

--- a/tests/unit/utils/test_schema_utils.py
+++ b/tests/unit/utils/test_schema_utils.py
@@ -152,6 +152,34 @@ def test_add_tag_path(schema, result):
     )
     schema_with_paths = add_paths_to_schema(collected_schemas_to_resolve[0])
     assert "TaggingPath" in schema_with_paths
-    assert "TaggingKey" in schema_with_paths
     assert schema_with_paths["TaggingPath"] == "/properties/Description/Tags"
-    assert schema_with_paths["TaggingKey"] == {"type": "string"}
+
+
+@pytest.mark.parametrize(
+    "schema,tagpath, tagkey",
+    [
+        (
+            "data/schemas-for-testing/schema-launch-template.json",
+            "/properties/Description/Tags",
+            {"type": "string"},
+        ),
+        (
+            "data/schemas-for-testing/schema-with-nonarrary-tags.json",
+            "/properties/Tags",
+            {"pattern": ".*"},
+        ),
+    ],
+)
+def test_add_tag_key(schema, tagpath, tagkey):
+    """Unit test to verify that schema has tag key definition"""
+    collected_schemas_to_resolve = collect_schemas(
+        schemas=[
+            "file:/"
+            + str(Path(os.path.dirname(os.path.realpath(__file__))).joinpath(schema))
+        ]
+    )
+    schema_with_paths = add_paths_to_schema(collected_schemas_to_resolve[0])
+    assert "TaggingPath" in schema_with_paths
+    assert schema_with_paths["TaggingPath"] == tagpath
+    assert "TaggingKey" in schema_with_paths
+    assert schema_with_paths["TaggingKey"] == tagkey

--- a/tests/unit/utils/test_schema_utils.py
+++ b/tests/unit/utils/test_schema_utils.py
@@ -152,4 +152,6 @@ def test_add_tag_path(schema, result):
     )
     schema_with_paths = add_paths_to_schema(collected_schemas_to_resolve[0])
     assert "TaggingPath" in schema_with_paths
+    assert "TaggingKey" in schema_with_paths
     assert schema_with_paths["TaggingPath"] == "/properties/Description/Tags"
+    assert schema_with_paths["TaggingKey"] == {"type": "string"}


### PR DESCRIPTION
**Description of changes:**
- Add a test ``TAG019`` to validate in the resource schema, its Tag Property is blocking the use of ``aws:`` | ``AWS:`` prefix tags. The rule will be shown as follows:
```
{
    "result": "WARNING",
    "check_id": "TAG019",
    "message": "Tagging Property should have pattern specified to block aws: prefix tags when Tagging Property is defined in the schema"
}
```
- To support the new test implementation, add a new function ``_add_tagging_key `` which retrieves the definition of ``Key`` inside tagProperty, check whether there is ``pattern`` specified and if the ``pattern`` is blocking AWS: prefix correctly
- It does not require the regex specified in schema be exactly as  ``^(?i)(?!aws:).*$``. As long as the resource schema defines a regex equal or stricter than this, e.g. ``^[A-Za-z][A-Za-z0-9-]*$``, it can pass the test.

**Different types of Tags:**
- The test support different types of Tags structure, including:
  - Default version: ``tagProperty`` is ``/properties/Tags`` and ``Tags`` is type of ``array``
  - Object Tags: ``tagProperty`` is ``/properties/Tags`` and ``Tags`` is type of ``object``
  - Self-named Tags: e.g. ``tagProperty`` is ``/properties/BackupVaultTags ``
  - Nested Tags: e.g. ``tagProperty`` is ``/properties/Description/Tags ``


- For resource with tagProperty as ``array``, its ``items`` definition is expected to have ``Key`` inside ``properties`` where ``Key`` has ``pattern`` for regex to block ``aws:`` prefix. Expected schema should like below:
```
{
    "definitions": {
        "Tags": {
            "type": "object",
            "properties": {
                "Key": {
                    "type": "string",
                    "pattern": "^(?i)(?!aws:).*$"
                }, ...,
            }
        }
    },
    "properties": {
        "Tags": {
            "type": "array",
            "items": {
                "$ref": "#/definitions/Tags"
            }
        }
    }
}
```

- For resource with tagProperty as object, it is expected to have ``patternProperties`` which specifies regex to block ``aws:`` prefix. Expected schema should like below:

```
{
    "properties": {
        "BackupVaultTags": {
            "type": "object",
            "patternProperties": {
                "^(?i)(?!aws:).*$": {
                    "type": "string"
                }
            }
        }
    }
}
```
- For tagProperties as type of ``object``, we require all regex in ``patternProperties`` to block ``aws:`` prefix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
