### PR TITLE
[Bugfix] GN001 Rule

### DIFF
--- a/src/rpdk/guard_rail/rule_library/core/schema-linter-core-rules.guard
+++ b/src/rpdk/guard_rail/rule_library/core/schema-linter-core-rules.guard
@@ -192,7 +192,7 @@ rule verify_property_notation
 
 
 rule ensure_description_is_descriptive {
-    description != /^Resource Type definition for/
+    description == /^Resource Type definition for/
     <<
     {
         "result": "WARNING",

--- a/tests/integ/runner/test_integ_runner.py
+++ b/tests/integ/runner/test_integ_runner.py
@@ -147,6 +147,13 @@ from rpdk.guard_rail.utils.arg_handler import collect_schemas
                         path="/taggable",
                     )
                 },
+                "ensure_description_is_descriptive": {
+                    GuardRuleResult(
+                        check_id="GN001",
+                        message="description should start with `Resource Type definition for ...`",
+                        path="/description",
+                    )
+                },
             },
         ),
         (


### PR DESCRIPTION
*Issue #, if available:*

- For Rule ``GN001``, fix its logic as we expect ``Description`` to match the pattern of start with `Resource Type definition for ...`
- Add an integration test


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
