### PR TITLE
Add print_diff_to_console flag

### DIFF
--- a/src/rpdk/guard_rail/core/data_types.py
+++ b/src/rpdk/guard_rail/core/data_types.py
@@ -52,6 +52,7 @@ class Stateful:
     current_schema: Dict[str, Any]
     previous_schema: Dict[str, Any]
     rules: List[str] = field(default_factory=list)
+    print_diff_to_console: bool = field(default=True)
 
 
 @dataclass(unsafe_hash=True)

--- a/src/rpdk/guard_rail/core/runner.py
+++ b/src/rpdk/guard_rail/core/runner.py
@@ -184,7 +184,9 @@ def _(payload):
         return output
 
     schema_difference = schema_diff(
-        previous_json=payload.previous_schema, current_json=payload.current_schema
+        previous_json=payload.previous_schema,
+        current_json=payload.current_schema,
+        print_diff_to_console=payload.print_diff_to_console,
     )
 
     schema_to_execute = __exec_rules__(schema=schema_difference)

--- a/src/rpdk/guard_rail/core/stateful.py
+++ b/src/rpdk/guard_rail/core/stateful.py
@@ -93,7 +93,11 @@ native_constructs = {
 }
 
 
-def schema_diff(previous_json: Dict[str, Any], current_json: Dict[str, Any]):
+def schema_diff(
+    previous_json: Dict[str, Any],
+    current_json: Dict[str, Any],
+    print_diff_to_console: bool = True,
+):
     """schema diff function to get formatted schema diff from deep diff"""
 
     previous_schema = resolve_schema(previous_json)
@@ -107,14 +111,15 @@ def schema_diff(previous_json: Dict[str, Any], current_json: Dict[str, Any]):
     )
 
     meta_diff = _translate_meta_diff(deep_diff.to_dict())
-    console.rule("[bold red][GENERATED DIFF BETWEEN SCHEMAS]")
-    console.print(
-        meta_diff,
-        style="link https://google.com",
-        highlight=True,
-        justify="left",
-        soft_wrap=True,
-    )
+    if print_diff_to_console:
+        console.rule("[bold red][GENERATED DIFF BETWEEN SCHEMAS]")
+        console.print(
+            meta_diff,
+            style="link https://google.com",
+            highlight=True,
+            justify="left",
+            soft_wrap=True,
+        )
     return meta_diff
 
 


### PR DESCRIPTION
*Issue #, if available:*
Resource "AWS::QuickSight::Template" has a lot of properties and definitions added to the template.  Which is exceeding the lambda memory usage.

*Description of changes:*

Add print_diff_to_console flag to disable printing if not needed maintaining backwards compatibility be setting it to true.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
