### PR TITLE
Fix: correct the path of required

### DIFF
--- a/src/rpdk/guard_rail/core/stateful.py
+++ b/src/rpdk/guard_rail/core/stateful.py
@@ -337,6 +337,14 @@ def _translate_dict_change(
                         schema_meta_diff, diffkey, _get_path(path_list), value
                     )
             if _is_json_construct(path_list):
+                """
+                Handles JSON schema construct paths and their 'required' fields.
+                If the last element in path_list is "required":
+                - For list/tuple values: Creates a list of paths by combining each value with the parent path
+                - For single values: Creates a single path by combining the value with the parent path
+                Otherwise:
+                - Returns the parent path without the last element
+                """
                 if path_list[-1] == "required":
                     if isinstance(value, (list, tuple)):
                         path_list_required = [

--- a/src/rpdk/guard_rail/core/stateful.py
+++ b/src/rpdk/guard_rail/core/stateful.py
@@ -337,14 +337,11 @@ def _translate_dict_change(
                         schema_meta_diff, diffkey, _get_path(path_list), value
                     )
             if _is_json_construct(path_list):
-                """
-                Handles JSON schema construct paths and their 'required' fields.
-                If the last element in path_list is "required":
-                - For list/tuple values: Creates a list of paths by combining each value with the parent path
-                - For single values: Creates a single path by combining the value with the parent path
-                Otherwise:
-                - Returns the parent path without the last element
-                """
+                # If the last element in path_list is "required":
+                # - For list/tuple values: Creates a list of paths by combining each value with the parent path
+                # - For single values: Creates a single path by combining the value with the parent path
+                # Otherwise:
+                # - Returns the parent path without the last element
                 if path_list[-1] == "required":
                     if isinstance(value, (list, tuple)):
                         path_list_required = [


### PR DESCRIPTION
*Issue #, if available:*
https://sim.amazon.com/issues/CFN-111635

*Description of changes:*
Make the path clear. 
If `required` : ["A"]
Then, diff path shows: 
added: {`required`: xxx/xxx/A}

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
