### PR TITLE
New rule: Verify that the tagging property has no wildcard

### DIFF
--- a/src/rpdk/guard_rail/rule_library/tags/schema-linter-core-tagging-rules.guard
+++ b/src/rpdk/guard_rail/rule_library/tags/schema-linter-core-tagging-rules.guard
@@ -134,6 +134,15 @@ rule ensure_property_tags_exists_v2 when tagging exists {
             }
             >>
 
+            tagging.tagProperty != /.*\*.*/
+            <<
+            {
+                "result": "NON_COMPLIANT",
+                "check_id": "TAG019",
+                "message": "`tagProperty` MUST NOT contain wildcards (*) in the path"
+            }
+            >>
+
             when writeOnlyProperties exists {
                 tagging.tagProperty !IN writeOnlyProperties
                 <<


### PR DESCRIPTION
Verifies that no wildcards are specified in the tagProperty of a schema.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
