### PR TITLE
fix false-positives on number type changes

### DIFF
--- a/src/rpdk/guard_rail/core/stateful.py
+++ b/src/rpdk/guard_rail/core/stateful.py
@@ -108,6 +108,7 @@ def schema_diff(
         current_schema,
         ignore_order_func=lambda level: "primaryIdentifier" not in level.path(),
         verbose_level=2,
+        ignore_type_in_groups=DeepDiff.numbers,
     )
 
     meta_diff = _translate_meta_diff(deep_diff.to_dict())

--- a/tests/integ/runner/test_integ_runner.py
+++ b/tests/integ/runner/test_integ_runner.py
@@ -653,6 +653,49 @@ def test_exec_compliance_stateless_not_taggable_with_tags(
             {},
             [],
         ),
+        (
+            {
+                "typeName": "AWS::Test:TypeName",
+                "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-connect",
+                "required": ["infos"],
+                "properties": {
+                    "infos": {
+                        "type": "array",
+                        "items": {"$ref": "#/definitions/info"},
+                        "insertionOrder": False,
+                    }
+                },
+                "definitions": {
+                    "level": {"type": "number", "minimum": 1.0, "maximum": 5.0},
+                    "info": {
+                        "type": "object",
+                        "properties": {"Level": {"$ref": "#/definitions/level"}},
+                    },
+                },
+            },
+            {
+                "typeName": "AWS::Test:TypeName",
+                "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-connect",
+                "required": ["infos"],
+                "properties": {
+                    "infos": {
+                        "type": "array",
+                        "items": {"$ref": "#/definitions/info"},
+                        "insertionOrder": False,
+                    }
+                },
+                "definitions": {
+                    "level": {"type": "number", "minimum": 1, "maximum": 5},
+                    "info": {
+                        "type": "object",
+                        "properties": {"Level": {"$ref": "#/definitions/level"}},
+                    },
+                },
+            },
+            [],
+            {},
+            [],
+        ),
     ],
 )
 def test_exec_compliance_stateful(


### PR DESCRIPTION
*Issue #, if available:*

Number type changes which add or remove trailing zeroes(ex:- 1 -> 1.0) in resource schema currently lead to a runtime error during Stateful check: `"Comparing incoming context with literals or dynamic results wasn't possible PathAwareValues are not comparable int, float"` from cfn-guard [here](https://github.com/aws-cloudformation/cloudformation-guard/blob/e12d831e915ac6d8f74222464f9b195d4aeab974/guard/src/rules/path_value.rs#L1063). 

resource-schema-guard-rail should not report that as a diff to cfn-guard in the first place.

*Description of changes:*
Set parameter`ignore_type_in_groups` in `DeepDiff` to ignore number type changes.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
